### PR TITLE
new FFI method: attach_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,33 @@ Examples:
       $return_string;
     });
 
+## attach\_method
+
+    $ffi->attach_method($object, $name => \@argument_types => $return_type);
+    $ffi->attach_method($object, [$c_name => $perl_name] => \@argument_types => $return_type);
+    $ffi->attach_method($object, [$address => $perl_name] => \@argument_types => $return_type);
+
+Like [attach](#attach), but the Perl xsub that is being created
+behaves like an object method of _$object_.  There is machinery
+behind the scenes to allow several objects in one class, potentially
+with different _$ffi_ objects, to share the xsub without interfering
+with each other's bindings.  However, it is only when one object is
+used primarily that performance will be almost as good as that of
+[attach](#attach).
+
+The current implementation locks the function and the [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus)
+instance into memory permanently; this is fixable, in theory.
+
+If just one _$name_ is given, then the function will be attached in
+Perl with the same name as it has in C.  The second form allows you to
+give the Perl function a different name.  You can also provide an
+address (the third form), just like with the [function](#function)
+method.
+
+Unlike [attach](#attach), there is no way to specify a _$wrapper_
+argument. If you need such a wrapper, you might as well handle the
+object detection in the wrapper sub.
+
 ## closure
 
     my $closure = $ffi->closure($coderef);

--- a/include/ffi_platypus_guts.h
+++ b/include/ffi_platypus_guts.h
@@ -57,6 +57,12 @@ void ffi_pl_perl_complex_double(SV *sv, double *ptr);
     sv_setnv(sv, *(ptr));                                        \
   }
 
+typedef struct _ffi_pl_cached_method {
+  SV *weakref;
+  ffi_pl_function *function;
+  HV *other_methods;
+} ffi_pl_cached_method;
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/FFI/Platypus.xs
+++ b/lib/FFI/Platypus.xs
@@ -41,6 +41,85 @@ XS(ffi_pl_sub_call)
 #include "ffi_platypus_call.h"
 }
 
+static ffi_pl_function *
+ffi_pl_make_method(ffi_pl_cached_method *cached, SV *object)
+{
+  dVAR;
+  dSP;
+  int count;
+
+  ffi_pl_function *function;
+  SV *function_object;
+
+  ENTER;
+  SAVETMPS;
+  PUSHMARK(SP);
+  XPUSHs(object);
+  XPUSHs(newRV_noinc((SV*)cached->other_methods));
+  PUTBACK;
+
+  count = call_pv("FFI::Platypus::_make_attach_method", G_SCALAR);
+  SPAGAIN;
+
+  if(count != 1)
+  {
+    croak("make_attach_method failed");
+  }
+
+  function_object = POPs;
+
+  if(!function_object || !SvROK(function_object)
+  || !sv_derived_from(function_object, "FFI::Platypus::Function"))
+  {
+    croak("make_attach_method failed");
+  }
+
+  function = INT2PTR(ffi_pl_function *, SvIV(SvRV(function_object)));
+
+  if(SvROK(object))
+  {
+    cached->weakref = newRV_inc(SvRV(object));
+    sv_rvweaken(cached->weakref);
+    cached->function = function;
+  }
+
+  FREETMPS;
+  LEAVE;
+
+  return function;
+}
+
+XS(ffi_pl_method_call)
+{
+  ffi_pl_cached_method *cached;
+  ffi_pl_function *self;
+  char *buffer;
+  size_t buffer_size;
+  int i,n, perl_arg_index;
+  SV *arg;
+  ffi_pl_result result;
+  ffi_pl_arguments *arguments;
+  void **argument_pointers;
+
+  dVAR; dXSARGS;
+
+  cached = (ffi_pl_cached_method *) CvXSUBANY(cv).any_ptr;
+  self = cached->function;
+
+  if(!cached->weakref || !SvROK(cached->weakref)
+  || (SvRV(cached->weakref) != SvRV(ST(0))))
+  {
+    self = ffi_pl_make_method(cached, ST(0));
+
+    if(!self) {
+      croak("could not generate a method on demand");
+    }
+  }
+
+#define EXTRA_ARGS 1
+#include "ffi_platypus_call.h"
+}
+
 /*
  * -1 until we have checked
  *  0 tried, not there


### PR DESCRIPTION
NOTE: I've implemented the changes I thought of as I was submitting the first pull request, and they're at https://github.com/plicease/FFI-Platypus/compare/master...pipcet:attach-object-method?expand=1. That includes documentation and tests, as well as some bug fixes.

it works like attach, but generates an XSUB which will check its first
argument to be the right object before discarding it and calling a C
function with the remaining arguments.

The tricky part is that the XSUB can be shared between different objects using different libraries and, in future, different "implementations". We cache the last function we've used, so performance should be very good in the typical case, but I haven't tested it. I've learned my lesson about hash lookups in inner loops, so we avoid that.

Now that I've written it, it occurs to me that it might be more useful behavior not to discard the first "object" method, but the specific application I had in mind requires it, and we can always add $ffi->attach_object_method($object, [object_function=>method], ['object'] =>'object') to handle that case.

Note that unlike ->attach, there is no reason we need to lock things into memory permanently: when $object is destroyed, the weak references to it will vanish and the hash entry it refers to will go stale; if necessary, we can even clean up stale hash entries once in a while (I'm not sure whether there is a Perl way of implementing a hash with weak keys, but that's what we'd use).

About the use case: I'm attaching to gdb, which has a function called parse_expression, with a const char \* argument and an opaque pointer return value, which I want to call as $gdb->parse_expression($string). Simply using ->attach would pass $gdb as the first argument, which breaks things, and using a wrapper is both slow and limited to a single object, and of course writing a wrapper sub for each method is out of the question.

On second thought, it might be better to define attach_method to work like this:

$ffi->attach_method($object, [function=>'method'] => ['object', 'int'] => 'opaque') makes $object->method(7) call function($object, 7) using $ffi's implementation and its library handles.

$ffi2->attach_method($object, [function=>'method'] => ['void', 'int'] => 'opaque') makes $object->method(7) call function(7) using $ffi2's implementation. (A 'void', in my head, is a type that translates a single Perl argument to zero native arguments on the stack, which is what we want in this case).

$ffi3->attach_method([$object=>$address], [function=>'method'] => ['opaque', 'int'] => 'opaque') makes $object->method(7) call function($address, 7) using $ffi3's implementation.

both of these or multiple variants of either can be combined in the same package.

What do you think? Sorry this got a bit long, but I feel it might be an interesting feature to have. It would be good to decide whether to use the explicit-'void' API or the implicitly discarding API before shipping anything, of course.
