### PR TITLE
use JSON to improve up to 30% slowdown when using JSON::PP instead of JSON::XS

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -30,7 +30,7 @@ my %module_build_args = (
     "Config::AutoConf" => "0.309",
     "ExtUtils::CBuilder" => 0,
     "FFI::CheckLib" => "0.05",
-    "JSON::PP" => 0,
+    "JSON" => 0,
     "Module::Build" => "0.3601",
     "perl" => "5.008001"
   },
@@ -46,7 +46,7 @@ my %module_build_args = (
   "requires" => {
     "FFI::CheckLib" => 0,
     "File::ShareDir" => 0,
-    "JSON::PP" => 0,
+    "JSON" => 0,
     "constant" => "1.32",
     "perl" => "5.008001"
   },

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires "FFI::CheckLib" => "0";
 requires "File::ShareDir" => "0";
-requires "JSON::PP" => "0";
+requires "JSON" => "0";
 requires "constant" => "1.32";
 requires "perl" => "5.008001";
 
@@ -19,7 +19,7 @@ on 'configure' => sub {
   requires "Config::AutoConf" => "0.309";
   requires "ExtUtils::CBuilder" => "0";
   requires "FFI::CheckLib" => "0.05";
-  requires "JSON::PP" => "0";
+  requires "JSON" => "0";
   requires "Module::Build" => "0.3601";
   requires "perl" => "5.008001";
 };

--- a/dist.ini
+++ b/dist.ini
@@ -111,7 +111,7 @@ Alien::FFI = 0.12
 ExtUtils::CBuilder = 0
 Config::AutoConf = 0.309
 FFI::CheckLib = 0.05
-JSON::PP = 0
+JSON = 0
 
 [Prereqs / TestPrereqs]
 -phase = test

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -127,10 +127,10 @@ XSLoader::load(
     # this is for testing without dzil
     # it expects MYMETA.json for FFI::Platypus
     # to be in the current working directory.
-    require JSON::PP;
+    require JSON;
     my $fh;
     open($fh, '<', 'MYMETA.json') || die "unable to read MYMETA.json";
-    my $config = JSON::PP::decode_json(do { local $/; <$fh> });
+    my $config = JSON::decode_json(do { local $/; <$fh> });
     close $fh;
     $config->{version};
   }

--- a/lib/FFI/Platypus/ShareConfig.pm
+++ b/lib/FFI/Platypus/ShareConfig.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::ShareDir qw( dist_dir );
 use File::Spec;
-use JSON::PP qw( decode_json );
+use JSON qw(decode_json);
 
 # VERSION
 

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -16,7 +16,7 @@ $modules{$_} = $_ for qw(
   ExtUtils::CBuilder
   FFI::CheckLib
   File::ShareDir
-  JSON::PP
+  JSON
   Module::Build
   PkgConfig
   Test::More

--- a/t/ffi_platypus_custom_type.t
+++ b/t/ffi_platypus_custom_type.t
@@ -2,13 +2,13 @@ use strict;
 use warnings;
 use Test::More;
 use FFI::Platypus;
-use JSON::PP;
+use JSON;
 BEGIN { eval q{ use YAML () } };
 
 sub xdump ($)
 {
   my($object) = @_;
-  note(YAML->can('Dump') ? YAML::Dump($object) : JSON::PP->new->allow_unknown->encode($object));
+  note(YAML->can('Dump') ? YAML::Dump($object) : JSON->new->allow_unknown->encode($object));
 }
 
 my $ffi = FFI::Platypus->new;

--- a/t/ffi_platypus_type.t
+++ b/t/ffi_platypus_type.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More tests => 8;
 use FFI::Platypus;
-use JSON::PP qw( encode_json );
+use JSON qw( encode_json );
 BEGIN { eval q{ use YAML () } };
 
 sub xdump ($)


### PR DESCRIPTION
FFI::Platypus::ShareConfig uses JSON::PP which is called enough that it causes a 20% to 30% slowdown across our test suite. This pull request uses JSON instead, which will choose JSON::XS if installed (which it is, in our case) or fall back to JSON::PP.
