### PR TITLE
move platypus to the Perl5-FFI org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FFI::Platypus [![Build Status](https://secure.travis-ci.org/plicease/FFI-Platypus.png)](http://travis-ci.org/plicease/FFI-Platypus) [![Build status](https://ci.appveyor.com/api/projects/status/dn0iuv0k7ld4ek2i/branch/master?svg=true)](https://ci.appveyor.com/project/plicease/FFI-Platypus/branch/master)
+# FFI::Platypus [![Build Status](https://secure.travis-ci.org/Perl5-FFI/FFI-Platypus.png)](http://travis-ci.org/Perl5-FFI/FFI-Platypus) [![Build status](https://ci.appveyor.com/api/projects/status/dn0iuv0k7ld4ek2i/branch/master?svg=true)](https://ci.appveyor.com/project/Perl5-FFI/FFI-Platypus/branch/master)
 
 Write Perl bindings to non-Perl libraries with FFI. No XS required.
 

--- a/dist.ini
+++ b/dist.ini
@@ -17,6 +17,8 @@ diag          = +PkgConfig
 irc           = irc://irc.perl.org/#native
 travis_status = 1
 appveyor      = dn0iuv0k7ld4ek2i
+github_user   = Perl5-FFI
+github_repo   = FFI-Platypus
 
 preamble = | #use Config;
 preamble = | #if($^O eq 'openbsd' && !$Config{usethreads} && do { require Alien::FFI; Alien::FFI->install_type eq 'system'})


### PR DESCRIPTION
I created Perl5-FFI some time ago, but have never used it.  I plan on moving most of my FFI related repositories to this org, starting with this one for the upcoming 0.49 or 0.50 release.  The intent is to help with succession planning.  Although at the moment I have the time an inclination to maintain Platypus and friends, I'd like it to carry on if possible if for some reason that I am unable to.

I also plan on creating a github pages based website in the Perl5-FFI org for Platypus friends at pl.atypus.org.  I have registered the domain but haven't started work yet on creating the website.