### PR TITLE
Probe for complex return types.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Improve platform probing of complex type
+  - Allow override of platform probing using FFI_PLATYPUS_PROBE_OVERRIDE
 
 0.67_01   2019-01-05 09:16:22 -0500
   - Better support for complex types: pointers to complex types and complex

--- a/inc/My/Probe.pm
+++ b/inc/My/Probe.pm
@@ -30,11 +30,26 @@ sub probe
   };
   
   my %probe;
+  if(defined $ENV{FFI_PLATYPUS_PROBE_OVERRIDE})
+  {
+    foreach my $kv (split /:/, $ENV{FFI_PLATYPUS_PROBE_OVERRIDE})
+    {
+      my($k,$v) = split /=/, $kv, 2;
+      $probe{$k} = $v;
+    }
+  }
   
   foreach my $cfile (bsd_glob 'inc/probe/*.c')
   {
     my $name = (File::Spec->splitpath($cfile))[2];
     $name =~ s{\.c$}{};
+
+    if(defined $probe{$name})
+    {
+      print "!!! WARNING !!! overriding $name=$probe{$name}\n";
+      delete $probe{$name} unless $probe{$name};
+      next;
+    }
     
     my $obj = eval { $b->compile(
       source               => $cfile,

--- a/inc/probe/complex.c
+++ b/inc/probe/complex.c
@@ -24,12 +24,24 @@ my_double_imag(double complex c)
   return cimag(c);
 }
 
+float complex
+my_float_complex_ret(float r, float i)
+{
+  return r + i*I;
+}
+
+double complex
+my_double_complex_ret(double r, double i)
+{
+  return r + i*I;
+}
+
 int
 main(int argc, char *argv[])
 {
   ffi_cif cif;
-  ffi_type *args[1];
-  void *values[1];
+  ffi_type *args[2];
+  void *values[2];
 
   args[0] = &ffi_type_complex_float;
 
@@ -73,6 +85,34 @@ main(int argc, char *argv[])
   else
   {
     return 2;
+  }
+
+  args[0] = &ffi_type_float;
+  args[1] = &ffi_type_float;
+
+  if(ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 2, &ffi_type_complex_float, args) == FFI_OK)
+  {
+    float complex answer;
+    float r=1.0, i=2.0;
+    values[0] = &r;
+    values[1] = &i;
+    ffi_call(&cif, (void*) my_float_complex_ret, &answer, values);
+    if(creal(answer) != 1.0 || cimag(answer) != 2.0)
+      return 2;
+  }
+
+  args[0] = &ffi_type_double;
+  args[1] = &ffi_type_double;
+
+  if(ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 2, &ffi_type_complex_double, args) == FFI_OK)
+  {
+    double complex answer;
+    double r=1.0, i=2.0;
+    values[0] = &r;
+    values[1] = &i;
+    ffi_call(&cif, (void*) my_double_complex_ret, &answer, values);
+    if(creal(answer) != 1.0 || cimag(answer) != 2.0)
+      return 2;
   }
 
   return 0;


### PR DESCRIPTION
After adding complex return types I noticed these cpantesters errors:

```
t/ffi_platypus_type_stringarray.t ........ ok
t/ffi_platypus_type_stringpointer.t ...... ok
t/forks.t ................................ skipped: Test requires forks
t/threads.t .............................. ok
t/type_complex_double.t .................. 
Dubious, test returned 5 (wstat 1280, 0x500)
All 2 subtests passed 

    #   Failed test 'standard'
    #   at t/type_complex_float.t line 96.
    #     Structures begin differing at:
    #          $got->[1] = '1.16316386109539e+023'
    #     $expected->[1] = '2'
    # Looks like you failed 1 test of 3.

#   Failed test 'return value'
#   at t/type_complex_float.t line 100.
# Looks like you failed 1 test of 3.
t/type_complex_float.t ................... 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/3 subtests 
t/type_double.t .......................... ok
t/type_float.t ........................... ok
t/type_longdouble.t ...................... ok
```

on windows.  After some poking around it looked like it was something borked with the platform, or libffi on windows.  So we should probe for return types when checking complex types.  Tacking on a way to override the probes.