### PR TITLE
Fix some regressions introduced in 0.77_01

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -210,4 +210,4 @@ match = \.dll$
 match = \.dylib$
 match = ^corpus/ffi_build_mm/project1/blib
 match = /_build/
-
+match = ^test-probe-

--- a/lib/FFI/Build/File/Base.pm
+++ b/lib/FFI/Build/File/Base.pm
@@ -271,6 +271,7 @@ sub needs_rebuild
   foreach my $source (@source)
   {
     my $source_time = [stat "$source"]->[9];
+    return 1 if ! defined $source_time;
     return 1 if $source_time > $target_time;
   }
   return 0;

--- a/lib/FFI/Build/Platform.pm
+++ b/lib/FFI/Build/Platform.pm
@@ -218,7 +218,9 @@ sub cxx
       return \@maybe if $self->which($maybe[0]);
     }
 
-    foreach my $maybe (qw( g++ clang++ ))
+    my @maybe = qw( c++ g++ clang++ );
+
+    foreach my $maybe (@maybe)
     {
       return [$maybe] if $self->which($maybe);
     }

--- a/t/ffi_build.t
+++ b/t/ffi_build.t
@@ -56,7 +56,7 @@ subtest 'build' => sub {
       my $build = FFI::Build->new('foo', 
         dir       => tempdir( "tmpbuild.XXXXXX", DIR => 'corpus/ffi_build/project1' ),
         buildname => "tmpbuild.tmpbuild.$$.@{[ time ]}",
-        verbose   => 1,
+        verbose   => 2,
       );
 
       my @source = $type eq 'name'
@@ -116,7 +116,7 @@ subtest 'build c++' => sub {
   my $build = FFI::Build->new('foo', 
     dir       => tempdir( "tmpbuild.XXXXXX", DIR => 'corpus/ffi_build/project-cxx' ),
     buildname => "tmpbuild.$$.@{[ time ]}",,
-    verbose   => 1,
+    verbose   => 2,
   );
   
   $build->source('corpus/ffi_build/project-cxx/*.cxx');
@@ -143,16 +143,33 @@ subtest 'build c++' => sub {
   platypus 2 => sub {
     my $ffi = shift;
     $ffi->lib($dll);
-  
-    is(
-      $ffi->function(foo1 => [] => 'int')->call,
-      42,
-    );
 
-    is(
-      $ffi->function(foo2 => [] => 'string')->call,
-      "42",
-    );
+    my $foo1 = eval { $ffi->function( foo1 => [] => 'int'    ) };
+    my $foo2 = eval { $ffi->function( foo2 => [] => 'string' ) };
+
+    ok defined $foo1, "foo1 found";
+    ok defined $foo2, "foo2 found";
+
+
+    SKIP: {
+      if(defined $foo1 && defined $foo2)
+      {
+        is(
+          $ffi->function(foo1 => [] => 'int')->call,
+          42,
+        );
+        is(
+          $ffi->function(foo2 => [] => 'string')->call,
+          "42",
+        );
+      }
+      else
+      {
+        diag "[build log follows]\n";
+        diag $out;
+        skip "foo1 or foo2 not found", 2 unless defined $foo1 && defined $foo2;
+      }
+    }
   };
 
   $build->clean;
@@ -173,7 +190,7 @@ subtest 'alien' => sub {
   my $build = FFI::Build->new('bar',
     dir       => tempdir( "tmpbuild.XXXXXX", DIR => 'corpus/ffi_build/project2' ),
     buildname => "tmpbuild.$$.@{[ time ]}",
-    verbose   => 1,
+    verbose   => 2,
     alien     => ['Acme::Alien::DontPanic'],
   );
   

--- a/t/ffi_build_file_base.t
+++ b/t/ffi_build_file_base.t
@@ -37,7 +37,7 @@ subtest 'basic' => sub {
 
     if($^O eq 'MSWin32')
     {
-      is($file->native, "corpus\\basic.foo", "native name");
+      is($file->native, "corpus\\ffi_build_file_base\\basic.foo", "native name");
     }
     else
     {

--- a/t/ffi_build_file_c.t
+++ b/t/ffi_build_file_c.t
@@ -35,7 +35,7 @@ subtest 'compile' => sub {
 subtest 'headers' => sub {
 
   my $build = FFI::Build->new('foo',
-    verbose => 1,
+    verbose => 2,
     cflags  => "-Icorpus/ffi_build_file_c/include",
   );
 

--- a/t/ffi_build_file_cxx.t
+++ b/t/ffi_build_file_cxx.t
@@ -40,7 +40,7 @@ subtest 'compile' => sub {
 subtest 'headers' => sub {
 
   my $build = FFI::Build->new('foo',
-    verbose => 1,
+    verbose => 2,
     cflags  => "-Icorpus/ffi_build_file_cxx/include",
   );
 


### PR DESCRIPTION
0.77_01 included a major refactor of the new probe/build code and understandably introduced some regressions in MSWin32 and FreeBSD (possibly other BSDs).  This fixes the major ones that were revealed in the first round of cpantesters results.

For FreeBSD we add `c++` as a the first C++ compiler to try.  Previously we were using `g++` first and `clang++` second.  On FreeBSD the C/C++ compiler now defaults to clang, which means `g++` is actually a mismatch to `cc`.  I considered probing `cc` to see which it is (since FreeBSD used to use gcc/g++), but then I remembered that FreeBSD also has a c++ alias which should be correct for both old and new FreeBSDs.

I've also made the C++ FFI::Build test a bit more verbose when it falls over, to make it easier to debug.