### PR TITLE
add test for strings

### DIFF
--- a/t/ffi/string.c
+++ b/t/ffi/string.c
@@ -78,7 +78,7 @@ string_test_pointer_arg(char **arg)
     sprintf(buffer, "*arg==%s", *arg);
 
   *arg = "out";
-  
+
   return buffer;
 }
 
@@ -92,4 +92,16 @@ string_test_pointer_ret(char *arg)
   else
     sprintf(buffer, "%s", arg);
   return (char**) &buffer;
+}
+
+EXTERN void
+string_write_to_string(char *dst, char *src)
+{
+  int i=0;
+  while(src[i] != '\0')
+  {
+    dst[i]=src[i];
+    i++;
+  }
+  dst[i]=0;
 }

--- a/t/type_string.t
+++ b/t/type_string.t
@@ -13,6 +13,7 @@ $ffi->attach( 'string_matches_foobarbaz'     => ['string'] => 'int');
 $ffi->attach( 'string_return_foobarbaz'      => []       => 'string');
 $ffi->attach( [pointer_null => 'null']       => []       => 'string');
 $ffi->attach( [pointer_is_null => 'is_null'] => ['string'] => 'int');
+$ffi->attach( 'string_write_to_string'       => ['string','string'] => 'void');
 
 ok string_matches_foobarbaz("foobarbaz"), "string_matches_foobarbaz(foobarbaz) = true";
 ok !string_matches_foobarbaz("x"), "string_matches_foobarbaz(foobarbaz) = false";
@@ -176,6 +177,15 @@ subtest 'argument update' => sub {
     \@args,
     [ "one", "two", "xx" ],
   );
+
+};
+
+subtest 'write to string' => sub {
+
+  my $src = 'hello world';
+  my $dst = ' ' x (length($src)+1);
+  string_write_to_string($dst, $src);
+  is($dst, "hello world\0");
 
 };
 


### PR DESCRIPTION
This adds a test for strings with a C function that writes into the buffer of a Perl scalar.  You have to be careful doing such things.  Anyway, I wrote this to test a bug that I was seeing in Alt-FFI-libffi.  I wasn't sure if it wasn't actually a FFI-Platypus bug.  It turned out not to be, but this is a useful test so we should add it to the test suite.