### PR TITLE
fix bug where wrong IV size is used

### DIFF
--- a/inc/My/Config.pm
+++ b/inc/My/Config.pm
@@ -206,10 +206,6 @@ sub configure
   {
     $ch->define_var( HAVE_IV_IS_64 => 1 );
   }
-  else
-  {
-    $ch->define_var( HAVE_IV_IS_64 => 0 );
-  }
 
   my %type_map;
   my %align;

--- a/maint/cip-test
+++ b/maint/cip-test
@@ -10,11 +10,18 @@ if perl -e 'exit ! ($] > 5.010)'; then
 
   cpanm -n local::lib
 
+  # workaround for rt128685.  These two lines
+  # can and should be removed once IO::Socket::SSL
+  # is unborked.  In so far as that is possible
+  # anyway.
+  cpanm -n Net::SSLeay
+  cpanm -n IO::Socket::SSL
+
   maint/cip-test-cpan FFI::Util
   maint/cip-test-cpan FFI::TinyCC
   maint/cip-test-cpan FFI::TinyCC::Inline
   maint/cip-test-cpan FFI::ExtractSymbols
-  
+
   maint/cip-test-cpan UUID::FFI
   maint/cip-test-cpan Acme::Ford::Prefect::FFI
   maint/cip-test-cpan File::LibMagic::FFI

--- a/t/ffi/gh117.c
+++ b/t/ffi/gh117.c
@@ -1,0 +1,7 @@
+#include "libtest.h"
+
+EXTERN uint64_t
+gh117()
+{
+  return 0xffffffffff;
+}

--- a/t/gh117.t
+++ b/t/gh117.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More;
+use FFI::CheckLib qw( find_lib );
+use FFI::Platypus;
+
+my $libtest = find_lib lib => 'test', symbol => 'f0', libpath => 't/ffi';
+my $ffi = FFI::Platypus->new;
+$ffi->lib($libtest);
+
+my $value64 = $ffi->function('gh117' => [] => 'uint64')->call;
+note "value64 = $value64";
+
+is($value64, "1099511627775");
+
+done_testing;


### PR DESCRIPTION
The logic for the probe is correct, if we have 64 it IVs, we set HAVE_IV_IS_64 to 1 and if not it is set to 0.  Unfortunately the code checks if HAVE_IV_IS_64 is defined.

Fix the probe so that it does not set HAVE_IV_IS_64 at all for Perls with 32 bit IVs.

This should address #117.