### PR TITLE
Remove an invalid shebang from a documentation

### DIFF
--- a/examples/get_uptime.pl
+++ b/examples/get_uptime.pl
@@ -1,4 +1,3 @@
-#!perl
 #Description: Get linux system uptime using GNOME libgtop library and FFI::Platypus
 #Refer: https://developer.gnome.org/libgtop/stable/libgtop-Uptime.html
 #Author: Bakkiaraj M

--- a/examples/win32_getSystemTime.pl
+++ b/examples/win32_getSystemTime.pl
@@ -1,4 +1,3 @@
-#!perl
 # Author : Bakkiaraj M
 # Script: Get System time from windows OS using GetLocalTime API.
 use strict;


### PR DESCRIPTION
Other example files also do not have. Make it uniform. (It actually triggers warnings when packaging for Fedora).

Signed-off-by: Petr Písař <ppisar@redhat.com>