### PR TITLE
add a custom mangler

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,24 @@ Examples:
     $ffi->type('int[128]' => 'myintarray');
     my $meta = $ffi->type_meta('myintarray'); # array of 128 ints
 
+## mangler
+
+    $ffi->mangler(\&mangler);
+
+Specify a customer mangler to be used for symbol lookup.  This is usually useful
+when you are writing bindings for a library where all of the functions have the
+same prefix.  Example:
+
+    $ffi->mangler(sub {
+      my($symbol) = @_;
+      return "foo_$symbol";
+    });
+    
+    $ffi->function( get_bar => [] => 'int' );  # attaches foo_get_bar
+    
+    my $f = $ffi->function( set_baz => ['int'] => 'void' );
+    $f->call(22); # calls foo_set_baz 
+
 ## function
 
     my $function = $ffi->function($name => \@argument_types => $return_type);

--- a/t/ffi/basic.c
+++ b/t/ffi/basic.c
@@ -22,3 +22,9 @@ f2(int *i)
 {
   *i = *i+1;
 }
+
+EXTERN int
+mystrangeprefix_bar(void)
+{
+  return 42;
+}

--- a/t/ffi_platypus.t
+++ b/t/ffi_platypus.t
@@ -773,4 +773,12 @@ subtest 'attach void' => sub {
 
 };
 
+subtest 'customer mangler' => sub {
+
+  my $ffi = FFI::Platypus->new;
+  $ffi->lib($libtest);
+  $ffi->mangler( sub { "mystrangeprefix_$_[0]" });
+  is($ffi->function(bar => [] => 'int')->call, 42 );
+};
+
 done_testing;


### PR DESCRIPTION
This allows you to specify a one-off mangler without needing to subclass Platypus, or use a language plugin.