### PR TITLE
Add support for variadic functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Add support for variadic functions (gh#136, gh#141)
 
 0.90      2019-07-01 09:47:31 -0400
   - Documentation improvements (gh#137, et. al.)

--- a/README.md
+++ b/README.md
@@ -339,6 +339,29 @@ Examples:
     my $function = $ffi->function('my_function_name', ['int', 'string'] => 'string');
     my $return_string = $function->(1, "hi there");
 
+\[version 0.91\]
+
+    my $function = $ffi->function( $name => \@fixed_argument_types => \@var_argument_types => $return_type);
+    my $function = $ffi->function( $name => \@fixed_argument_types => \@var_argument_types => $return_type, \&wrapper);
+
+Version 0.91 and later allows you to creat functions for c variadic functions
+(such as printf, scanf, etc) which can take a variable number of arguments.
+The first set of arguments are the fixed set, the second set are the variable
+arguments to bind with.  The variable argument types must be specified in order
+to create a function object, so if you need to call variadic function with
+different set of arguments then you will need to create a new function object
+each time:
+
+    # int printf(const char *fmt, ...);
+    $ffi->function( printf => ['string'] => ['int'] => 'int' )
+        ->call("print integer %d\n", 42);
+    $ffi->function( printf => ['string'] => ['string'] => 'int' )
+        ->call("print string %s\n", 'platypus');
+
+Some older versions of libffi and possibly some platforms may not support
+variadic functions.  If you try to create a one, then an exception will be
+thrown.
+
 ## attach
 
     $ffi->attach($name => \@argument_types => $return_type);
@@ -385,6 +408,16 @@ Examples:
       $return_string =~ s/Belgium//; # HHGG remove profanity
       $return_string;
     });
+
+\[version 0.91\]
+
+    $ffi->attach($name => \@fixed_argument_types => \@var_argument_types, $return_type);
+    $ffi->attach($name => \@fixed_argument_types => \@var_argument_types, $return_type, \&wrapper);
+
+As of version 0.91 you can attach a variadic functions, if it is supported
+by the platform / libffi that you are using.  For details see the `function`
+documentation.  If not supported by the implementation then an exception
+will be thrown.
 
 ## closure
 

--- a/inc/probe/variadic.c
+++ b/inc/probe/variadic.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <ffi.h>
+
+int
+return_arg(int which, ...)
+{
+  va_list args;
+  va_start(args, which);
+  int i, val;
+
+  for(i=0; i<which; i++)
+  {
+    val = va_arg(args, int);
+  }
+
+  va_end(args);
+
+  return val;
+}
+
+int
+basic_test()
+{
+  int answer;
+
+  answer = return_arg(4,10,20,30,40,50,60,70);
+
+  if(answer != 40)
+  {
+    /* basic varadic function fail */
+    printf("basic answer = %d\n", answer);
+    return 2;
+  }
+
+  return 0;
+}
+
+int
+ffi_test()
+{
+  ffi_cif cif;
+  ffi_type *args[8]   = { &ffi_type_sint32, &ffi_type_sint32, &ffi_type_sint32, &ffi_type_sint32, &ffi_type_sint32, &ffi_type_sint32, &ffi_type_sint32, &ffi_type_sint32 };
+  int values[8] = { 4,10,20,30,40,50,60,70 };
+  void *ptrvalues[8]  = { &values[0], &values[1], &values[2], &values[3], &values[4], &values[5], &values[6], &values[7] };
+  int answer = -1;
+
+  if(ffi_prep_cif_var(&cif, FFI_DEFAULT_ABI, 1, 7, &ffi_type_sint32, args) == FFI_OK)
+  {
+    ffi_call(&cif, (void*) return_arg, &answer, ptrvalues);
+    if(answer != 40)
+    {
+      printf("ffi ansewr = %d\n", answer);
+      return 2;
+    }
+    else
+    {
+      return 0;
+    }
+  }
+  else
+  {
+    return 2;
+  }
+}
+
+int
+dlmain(int argc, char *argv[])
+{
+  if(basic_test())
+    return 2;
+  if(ffi_test())
+    return 2;
+  return 0;
+}

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -637,6 +637,29 @@ Examples:
  my $function = $ffi->function('my_function_name', ['int', 'string'] => 'string');
  my $return_string = $function->(1, "hi there");
 
+[version 0.91]
+
+ my $function = $ffi->function( $name => \@fixed_argument_types => \@var_argument_types => $return_type);
+ my $function = $ffi->function( $name => \@fixed_argument_types => \@var_argument_types => $return_type, \&wrapper);
+
+Version 0.91 and later allows you to creat functions for c variadic functions
+(such as printf, scanf, etc) which can take a variable number of arguments.
+The first set of arguments are the fixed set, the second set are the variable
+arguments to bind with.  The variable argument types must be specified in order
+to create a function object, so if you need to call variadic function with
+different set of arguments then you will need to create a new function object
+each time:
+
+ # int printf(const char *fmt, ...);
+ $ffi->function( printf => ['string'] => ['int'] => 'int' )
+     ->call("print integer %d\n", 42);
+ $ffi->function( printf => ['string'] => ['string'] => 'int' )
+     ->call("print string %s\n", 'platypus');
+
+Some older versions of libffi and possibly some platforms may not support
+variadic functions.  If you try to create a one, then an exception will be
+thrown.
+
 =cut
 
 sub function
@@ -728,6 +751,16 @@ Examples:
    $return_string =~ s/Belgium//; # HHGG remove profanity
    $return_string;
  });
+
+[version 0.91]
+
+ $ffi->attach($name => \@fixed_argument_types => \@var_argument_types, $return_type);
+ $ffi->attach($name => \@fixed_argument_types => \@var_argument_types, $return_type, \&wrapper);
+
+As of version 0.91 you can attach a variadic functions, if it is supported
+by the platform / libffi that you are using.  For details see the C<function>
+documentation.  If not supported by the implementation then an exception
+will be thrown.
 
 =cut
 

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -643,14 +643,25 @@ sub function
 {
   my $wrapper;
   $wrapper = pop if ref $_[-1] eq 'CODE';
-  my($self, $name, $args, $ret) = @_;
-  croak "usage \$ffi->function( name, [ arguments ], return_type)" unless @_ == 4 || @_ == 5;
+
+  croak "usage \$ffi->function( name, [ arguments ], return_type)" unless @_ >= 4 && @_ <= 6;
+
+  my $self = shift;
+  my $name = shift;
+  my $fixed_args = shift;
+  my $var_args;
+  $var_args = shift if defined $_[0] && ref($_[0]) eq 'ARRAY';
+  my $ret = shift;
+
+  my $args = [@$fixed_args, @{ $var_args || [] } ];
+  my $fixed_arg_count = defined $var_args ? scalar(@$fixed_args) : -1;
+
   my @args = map { $self->_type_lookup($_) || croak "unknown type: $_" } @$args;
   $ret = $self->_type_lookup($ret) || croak "unknown type: $ret";
   my $address = $name =~ /^-?[0-9]+$/ ? $name : $self->find_symbol($name);
   croak "unable to find $name" unless defined $address || $self->ignore_not_found;
   return unless defined $address;
-  my $function = FFI::Platypus::Function::Function->new($self, $address, $self->{abi}, -1, $ret, @args);
+  my $function = FFI::Platypus::Function::Function->new($self, $address, $self->{abi}, $fixed_arg_count, $ret, @args);
   $wrapper
     ? FFI::Platypus::Function::Wrapper->new($function, $wrapper)
     : $function;

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -643,15 +643,14 @@ sub function
 {
   my $wrapper;
   $wrapper = pop if ref $_[-1] eq 'CODE';
-
   my($self, $name, $args, $ret) = @_;
-  croak "usage \$ffi->function( name, [ arguments ], return_type)" unless (@_ == 4) || (@_ == 5);
+  croak "usage \$ffi->function( name, [ arguments ], return_type)" unless @_ == 4 || @_ == 5;
   my @args = map { $self->_type_lookup($_) || croak "unknown type: $_" } @$args;
   $ret = $self->_type_lookup($ret) || croak "unknown type: $ret";
   my $address = $name =~ /^-?[0-9]+$/ ? $name : $self->find_symbol($name);
   croak "unable to find $name" unless defined $address || $self->ignore_not_found;
   return unless defined $address;
-  my $function = FFI::Platypus::Function::Function->new($self, $address, $self->{abi}, $ret, @args);
+  my $function = FFI::Platypus::Function::Function->new($self, $address, $self->{abi}, -1, $ret, @args);
   $wrapper
     ? FFI::Platypus::Function::Wrapper->new($function, $wrapper)
     : $function;

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -738,7 +738,13 @@ sub attach
   my $wrapper;
   $wrapper = pop if ref $_[-1] eq 'CODE';
 
-  my($self, $name, $args, $ret, $proto) = @_;
+  my $self = shift;
+  my $name = shift;
+  my $args = shift;
+  my $varargs = shift if defined $_[0] && ref($_[0]) eq 'ARRAY';
+  my $ret = shift;
+  my $proto = shift;
+
   $ret = 'void' unless defined $ret;
 
   my($c_name, $perl_name) = ref($name) ? @$name : ($name, $name);
@@ -746,7 +752,9 @@ sub attach
   croak "you tried to provide a perl name that looks like an address"
     if $perl_name =~ /^-?[0-9]+$/;
   
-  my $function = $self->function($c_name, $args, $ret, $wrapper);
+  my $function = $varargs
+    ? $self->function($c_name, $args, $varargs, $ret, $wrapper)
+    : $self->function($c_name, $args, $ret, $wrapper);
   
   if(defined $function)
   {

--- a/t/ffi/variadic.c
+++ b/t/ffi/variadic.c
@@ -1,0 +1,23 @@
+#include <ffi_platypus.h>
+#ifdef FFI_PL_PROBE_VARIADIC
+#include <stdio.h>
+#include <stdarg.h>
+
+int
+variadic_return_arg(int which, ...)
+{
+  va_list args;
+  va_start(args, which);
+  int i, val;
+
+  for(i=0; i<which; i++)
+  {
+    val = va_arg(args, int);
+  }
+
+  va_end(args);
+
+  return val;
+}
+
+#endif

--- a/t/ffi_platypus_function.t
+++ b/t/ffi_platypus_function.t
@@ -131,6 +131,12 @@ subtest 'variadic' => sub {
   my $ffi = FFI::Platypus->new;
   $ffi->lib($libtest);
 
+  my $wrapper = sub {
+    my($xsub, @args) = @_;
+    my $ret = $xsub->(@args);
+    $ret*2;
+  };
+
   subtest 'unattached' => sub {
 
     is(
@@ -139,12 +145,6 @@ subtest 'variadic' => sub {
       'sans wrapper'
     );
 
-    my $wrapper = sub {
-      my($xsub, @args) = @_;
-      my $ret = $xsub->(@args);
-      $ret*2;
-    };
-
     is(
       $ffi->function(variadic_return_arg => ['int'] => ['int','int','int','int','int','int','int'] => 'int', $wrapper)->call(4,10,20,30,40,50,60,70),
       80,
@@ -152,11 +152,15 @@ subtest 'variadic' => sub {
     );
   };
 
-  #sub 'attached' => sub {
-#
-#    $ffi->attach([variadic_return_arg => 'y1'] => ['int']
-#
-#  };
+  subtest 'attached' => sub {
+
+    $ffi->attach([variadic_return_arg => 'y1'] => ['int'] => ['int','int','int','int','int','int','int'] => 'int');
+    is(y1(4,10,20,30,40,50,60,70), 40, 'sans wrapper');
+
+    $ffi->attach([variadic_return_arg => 'y2'] => ['int'] => ['int','int','int','int','int','int','int'] => 'int', $wrapper);
+    is(y2(4,10,20,30,40,50,60,70), 80, 'with wrapper');
+
+  };
 
 };
 

--- a/t/ffi_platypus_function.t
+++ b/t/ffi_platypus_function.t
@@ -126,5 +126,39 @@ subtest 'prototype' => sub {
 
 };
 
+subtest 'variadic' => sub {
+
+  my $ffi = FFI::Platypus->new;
+  $ffi->lib($libtest);
+
+  subtest 'unattached' => sub {
+
+    is(
+      $ffi->function(variadic_return_arg => ['int'] => ['int','int','int','int','int','int','int'] => 'int')->call(4,10,20,30,40,50,60,70),
+      40,
+      'sans wrapper'
+    );
+
+    my $wrapper = sub {
+      my($xsub, @args) = @_;
+      my $ret = $xsub->(@args);
+      $ret*2;
+    };
+
+    is(
+      $ffi->function(variadic_return_arg => ['int'] => ['int','int','int','int','int','int','int'] => 'int', $wrapper)->call(4,10,20,30,40,50,60,70),
+      80,
+      'with wrapper'
+    );
+  };
+
+  #sub 'attached' => sub {
+#
+#    $ffi->attach([variadic_return_arg => 'y1'] => ['int']
+#
+#  };
+
+};
+
 done_testing;
 

--- a/t/ffi_platypus_function.t
+++ b/t/ffi_platypus_function.t
@@ -131,6 +131,10 @@ subtest 'variadic' => sub {
   my $ffi = FFI::Platypus->new;
   $ffi->lib($libtest);
 
+  plan skip_all => 'test requires variadic function support'
+    unless eval { $ffi->function('variadic_return_arg' => ['int'] => ['int'] => 'int') };
+
+
   my $wrapper = sub {
     my($xsub, @args) = @_;
     my $ret = $xsub->(@args);

--- a/t/ffi_platypus_function.t
+++ b/t/ffi_platypus_function.t
@@ -37,7 +37,7 @@ subtest 'private' => sub {
   my $address = $ffi->find_symbol('f0');
   my $uint8   = FFI::Platypus::Type->new('uint8');
 
-  my $function = eval { FFI::Platypus::Function::Function->new($ffi, $address, -1, $uint8, $uint8) };
+  my $function = eval { FFI::Platypus::Function::Function->new($ffi, $address, -1, -1, $uint8, $uint8) };
   is $@, '', 'FFI::Platypus::Function->new';
   isa_ok $function, 'FFI::Platypus::Function';
   isa_ok $function, 'FFI::Platypus::Function::Function';
@@ -127,3 +127,4 @@ subtest 'prototype' => sub {
 };
 
 done_testing;
+

--- a/xs/Function.xs
+++ b/xs/Function.xs
@@ -20,6 +20,12 @@ new(class, platypus, address, abi, var_fixed_args, return_type, ...)
     int extra_arguments;
   CODE:
     (void)class;
+#ifndef FFI_PL_PROBE_VARIADIC
+    if(var_fixed_args != -1)
+    {
+      croak("variadic functions are not supported by some combination of your libffi/compiler/platypus");
+    }
+#endif
     ffi_abi = abi == -1 ? FFI_DEFAULT_ABI : abi;
 
     for(i=0,extra_arguments=0; i<(items-6); i++)
@@ -74,6 +80,7 @@ new(class, platypus, address, abi, var_fixed_args, return_type, ...)
     }
     else
     {
+#ifdef FFI_PL_PROBE_VARIADIC
       ffi_status = ffi_prep_cif_var(
         &self->ffi_cif,                           /* ffi_cif     | */
         ffi_abi,                                  /* ffi_abi     | */
@@ -82,6 +89,7 @@ new(class, platypus, address, abi, var_fixed_args, return_type, ...)
         ffi_return_type,                          /* ffi_type *  | return type */
         ffi_argument_types                        /* ffi_type ** | argument types */
       );
+#endif
     }
 
     if(ffi_status != FFI_OK)


### PR DESCRIPTION
This addresses #136 

C functions like:

```c
void sprintf(char *buffer, const char *fmt, ...);
```

require libffi support for "variadic" functions, which has been supported by `libffi` for a while, but not in Platypus until now.  The proposed Platypus interface here is thus:

```perl
{
  my $f = $ffi->function( sprintf => ['string','string'] => ['int','string'] => 'void' );
  my $buffer = "\0" x 200;
  $f->($buffer, "an integer = %d and a string = %s", 42, "perl");
}
{
  my $f = $ffi->attach( [sprintf => 'mysprintf'] => ['string','string'] => ['int','string'] => 'void' );
  my $buffer = "\0" x 200;
  mysprintf($buffer, "an integer = %d and a string = %s", 42, "perl");
}
```

Essentially, allow the user to specify a second list of variable arguments.  On systems where libffi doesn't support variadic functions the `function` or `attach` method will throw an exception.

I also considered adding a `variadic_function` or `vfunction` method that builds a variadic function and keeping the interface for the existing `function` and `attach` methods.  The downside to this is that you'd also need an `vattach` function or require `->function(...)->attach` like calls for variadic functions.  Because of the dynamic nature of variadic functions, maybe that isn't so bad?  On the other hand the interface proposed is backwards compatible in that there aren't any calls to the `function` or `attach` method that were previously legal that are now ambiguous.

remaining tasks:

 - [x] add POD documentation