### PR TITLE
handle void type as argument better

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,6 +13,12 @@ Revision history for {{$dist->name}}
   - Fix bug where Math::LongDouble and Math::Complex detection
     wasn't being made for array and pointers of longdouble,
     complex_float and complex_double types. (gh#135)
+  - For functions: allow a single 'void' argument type to indicate
+    an empty list of arguments (a la old C style).  The 'void'
+    type is otherwise now illegal as an argument type (ie when
+    there is more than one argument) and will throw an exception
+    when the function is created.  Previously a warning would
+    be issued when the funtion was called. (gh#140, gh#142)
 
 0.90      2019-07-01 09:47:31 -0400
   - Documentation improvements (gh#137, et. al.)

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -664,6 +664,13 @@ sub function
   $var_args = shift if defined $_[0] && ref($_[0]) eq 'ARRAY';
   my $ret = shift;
 
+  # special case: treat a single void argument type as an empty list of
+  # arguments, a la olde timey C compilers.
+  if( (!defined $var_args) && @$fixed_args == 1 && $fixed_args->[0] eq 'void' )
+  {
+    $fixed_args = [];
+  }
+
   my $args = [@$fixed_args, @{ $var_args || [] } ];
   my $fixed_arg_count = defined $var_args ? scalar(@$fixed_args) : -1;
 

--- a/t/ffi_platypus_function.t
+++ b/t/ffi_platypus_function.t
@@ -169,5 +169,14 @@ subtest 'variadic' => sub {
 
 };
 
+subtest 'void as arg should fail is arg count > 1' => sub {
+
+  my $ffi = FFI::Platypus->new;
+
+  eval { $ffi->function( 0 => ['int','void'] => 'void' ) };
+  like "$@", qr/^void not allowed as argument type/;
+
+};
+
 done_testing;
 

--- a/t/ffi_platypus_function.t
+++ b/t/ffi_platypus_function.t
@@ -178,5 +178,14 @@ subtest 'void as arg should fail is arg count > 1' => sub {
 
 };
 
+subtest 'single void arg treated as no args' => sub {
+
+  my $ffi = FFI::Platypus->new;
+
+  eval { $ffi->function( 0 => ['void'] => 'void' ) };
+  is "$@", "";
+
+};
+
 done_testing;
 

--- a/xs/Function.xs
+++ b/xs/Function.xs
@@ -42,6 +42,8 @@ new(class, platypus, address, abi, var_fixed_args, return_type, ...)
         croak("non-type parameter passed in as type");
       }
       arg_type = INT2PTR(ffi_pl_type*, SvIV((SV*) SvRV(arg)));
+      if(arg_type->type_code == FFI_PL_TYPE_VOID)
+        croak("void not allowed as argument type");
       if((arg_type->type_code & FFI_PL_SHAPE_MASK) == FFI_PL_SHAPE_CUSTOM_PERL)
         extra_arguments += arg_type->extra[0].custom_perl.argument_count;
     }


### PR DESCRIPTION
For #140 : 

 - disallow `void` as an argument type when there is > 1 argument type
 - allow single `void` to indicate an empty list of argument types _a la_ olde timey C.