### PR TITLE
Probe for enum and signed enum types.

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
   - Add support for returning records pass-by-value (gh#89, gh#147)
+  - Add enum and senum (signed enum) types (gh#146)
 
 0.92      2019-07-17 18:16:40 -0400
   - Production release identical to 0.91_02

--- a/inc/My/Config.pm
+++ b/inc/My/Config.pm
@@ -50,6 +50,8 @@ _Bool
 pointer
 uintptr_t
 intptr_t
+enum
+senum
 EOF
 
 my @extra_probe_types = split /\n/, <<EOF;
@@ -214,8 +216,6 @@ sub configure
 
   foreach my $type (@probe_types)
   {
-    my $ok;
-
     if($type =~ /^(float|double|long double)/)
     {
       if(my $basic = $probe->check_type_float($type))
@@ -228,6 +228,22 @@ sub configure
     {
       $probe->check_type_pointer;
       $align{pointer} = $probe->data->{type}->{pointer}->{align};
+    }
+    elsif($type eq 'enum')
+    {
+      if(my $basic = $probe->check_type_enum)
+      {
+        $type_map{enum} = $basic;
+        $align{$basic} ||= $probe->data->{type}->{enum}->{align};
+      }
+    }
+    elsif($type eq 'senum')
+    {
+      if(my $basic = $probe->check_type_signed_enum)
+      {
+        $type_map{senum} = $basic;
+        $align{$basic} ||= $probe->data->{type}->{senum}->{align};
+      }
     }
     else
     {

--- a/lib/FFI/Platypus/TypeParser/Version1.pm
+++ b/lib/FFI/Platypus/TypeParser/Version1.pm
@@ -46,6 +46,9 @@ our @CARP_NOT = qw( FFI::Platypus FFI::Platypus::TypeParser );
 
 my %reserved = map { $_ => 1 } qw(
   struct
+  record
+  string
+  senum
   enum
 );
 


### PR DESCRIPTION
According to the standard, a c compiler is free to choose any type it wants for an enum, and for different enums it doesn't have to use the same underlying type.  In practice enums are usually a fixed integer type (possibly signed / unsigned).  This PR probes for the integer type of a very small signed and unsigned enum types.  Some documentation for this (and its limitations) is probably in order for `FFI::Platypus::Type`.