### PR TITLE
add support for pass-by-value records as a return type

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Add support for returning records pass-by-value (gh#89, gh#147)
 
 0.91_02   2019-07-16 19:31:40 -0400
   - Documentation improvements. (gh#139, gh#145, et. al)

--- a/inc/pdb
+++ b/inc/pdb
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use lib 'inc';
+use lib 'lib';
+use FFI::Probe;
+use FFI::Probe::Runner;
+use FFI::Probe::Runner::Builder;
+use My::ShareConfig;
+use File::Temp qw( tempdir );
+use Path::Tiny qw( path );
+
+my $dir = tempdir( CLEANUP => 1 );
+my $data_filename = path( $dir, 'probe.pl' );
+my $log_filename  = path( $dir, 'config.log' );
+
+my $probe = FFI::Probe->new(
+  runner => do {
+    my $builder = FFI::Probe::Runner::Builder->new;
+    my $exe = $builder->exe;
+    FFI::Probe::Runner->new( exe => $exe );
+  },
+  log => "$log_filename",
+  data_filename => "$data_filename",
+  alien => [My::ShareConfig->new->get('alien')->{class}],
+  cflags => ['-Iinclude'],
+);
+
+my $name = shift @ARGV;
+$name ||= 'recordvalue'; # this is what I am strugling with right this minute.
+my $fn = "inc/probe/$name.c";
+my $code = do {
+  my $fh;
+  open $fh, '<', $fn;
+  local $/;
+  <$fh>;
+};
+
+my $value = $probe->check($name, $code);
+
+$probe->save;
+
+print "[log]\n";
+print $log_filename->slurp;
+print "[data]\n";
+print $data_filename->slurp;

--- a/inc/probe/recordvalue.c
+++ b/inc/probe/recordvalue.c
@@ -25,27 +25,32 @@ dlmain(int argc, char *argv[])
   ffi_type ffi_type_foo_t;
   int i;
   foo_t foo;
+  ffi_type *arg_types[1] = { &ffi_type_void };
+  void *args[1] = { NULL };
 
   ffi_type_foo_t.size = ffi_type_foo_t.alignment = 0;
   ffi_type_foo_t.type = FFI_TYPE_STRUCT;
-  ffi_type_foo_t.elements = calloc(14, sizeof(ffi_type*));
+  ffi_type_foo_t.elements = calloc(15, sizeof(ffi_type*));
 
   for(i=0; i<13; i++)
     ffi_type_foo_t.elements[i] = is_signed(char) ? &ffi_type_sint8 : &ffi_type_uint8;
   ffi_type_foo_t.elements[13] = &ffi_type_sint32;
+  ffi_type_foo_t.elements[14] = NULL;
 
-  if(ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 0, &ffi_type_foo_t, NULL) == FFI_OK)
+  if(ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 0, &ffi_type_foo_t, arg_types) == FFI_OK)
   {
-    ffi_call(&cif, (void*) get_foo, &foo, NULL);
+
+    ffi_call(&cif, (void*) get_foo, &foo, args);
+
     if(strcmp(foo.name, "hello"))
       return 2;
+
     if(foo.value != 42)
       return 2;
+
   }
   else
-  {
     return 2;
-  }
 
   return 0;
 }

--- a/inc/probe/recordvalue.c
+++ b/inc/probe/recordvalue.c
@@ -2,6 +2,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#define is_signed(type)  ((((type)-1) < 0) ? 1 : 0)
+
 typedef struct {
   char name[13];
   int value;
@@ -29,7 +31,7 @@ dlmain(int argc, char *argv[])
   ffi_type_foo_t.elements = calloc(14, sizeof(ffi_type*));
 
   for(i=0; i<13; i++)
-    ffi_type_foo_t.elements[i] = &ffi_type_sint8;
+    ffi_type_foo_t.elements[i] = is_signed(char) ? &ffi_type_sint8 : &ffi_type_uint8;
   ffi_type_foo_t.elements[13] = &ffi_type_sint32;
 
   if(ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 0, &ffi_type_foo_t, NULL) == FFI_OK)

--- a/inc/probe/recordvalue.c
+++ b/inc/probe/recordvalue.c
@@ -1,0 +1,49 @@
+#include <ffi.h>
+#include <string.h>
+#include <stdlib.h>
+
+typedef struct {
+  char name[13];
+  int value;
+} foo_t;
+
+foo_t
+get_foo(void)
+{
+  foo_t self;
+  strcpy(self.name, "hello");
+  self.value = 42;
+  return self;
+}
+
+int
+dlmain(int argc, char *argv[])
+{
+  ffi_cif cif;
+  ffi_type ffi_type_foo_t;
+  int i;
+  foo_t foo;
+
+  ffi_type_foo_t.size = ffi_type_foo_t.alignment = 0;
+  ffi_type_foo_t.type = FFI_TYPE_STRUCT;
+  ffi_type_foo_t.elements = calloc(14, sizeof(ffi_type*));
+
+  for(i=0; i<13; i++)
+    ffi_type_foo_t.elements[i] = &ffi_type_sint8;
+  ffi_type_foo_t.elements[13] = &ffi_type_sint32;
+
+  if(ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 0, &ffi_type_foo_t, NULL) == FFI_OK)
+  {
+    ffi_call(&cif, (void*) get_foo, &foo, NULL);
+    if(strcmp(foo.name, "hello"))
+      return 2;
+    if(foo.value != 42)
+      return 2;
+  }
+  else
+  {
+    return 2;
+  }
+
+  return 0;
+}

--- a/lib/FFI/Platypus.xs
+++ b/lib/FFI/Platypus.xs
@@ -41,7 +41,6 @@ XS(ffi_pl_sub_call)
   ffi_pl_function *self;
   int i,n, perl_arg_index;
   SV *arg;
-  ffi_pl_result result;
   ffi_pl_arguments *arguments;
   void **argument_pointers;
 

--- a/lib/FFI/Probe.pm
+++ b/lib/FFI/Probe.pm
@@ -123,7 +123,7 @@ sub check_header
   $code .= "#include <$_>\n" for @{ $self->{headers} }, $header;
 
   my $build = FFI::Build->new("hcheck@{[ ++$self->{counter} ]}",
-    verbose => 1,
+    verbose => 2,
     dir     => $self->{dir},
     alien   => $self->{alien},
     cflags  => $self->{cflags},
@@ -161,7 +161,7 @@ sub check_cpp
   my($self, $code) = @_;
 
   my $build = FFI::Build->new("hcheck@{[ ++$self->{counter} ]}",
-    verbose => 1,
+    verbose => 2,
     dir     => $self->{dir},
     alien   => $self->{alien},
     cflags  => $self->{cflags},
@@ -243,7 +243,7 @@ sub check_eval
   $code =~ s/##EVAL##/$eval/;
 
   my $build = FFI::Build->new("eval@{[ ++$self->{counter} ]}",
-    verbose => 1,
+    verbose => 2,
     dir     => $self->{dir},
     alien   => $self->{alien},
     cflags  => $self->{cflags},

--- a/lib/FFI/Probe/Runner.pm
+++ b/lib/FFI/Probe/Runner.pm
@@ -97,6 +97,7 @@ sub verify
   my($self) = @_;
   my $exe = $self->exe;
   my($out, $err, $ret) = capture {
+    $! = 0;
     system $exe, 'verify', 'self';
   };
   return 1 if $ret == 0 && $out =~ /dlrun verify self ok/;
@@ -122,6 +123,7 @@ sub run
   my $flags = $self->flags;
   my($out, $err, $ret) = capture {
     my @cmd = ($exe, $dll, $flags, @args);
+    $! = 0;
     system @cmd;
     $?;
   };

--- a/t/ffi/record.c
+++ b/t/ffi/record.c
@@ -2,7 +2,7 @@
 #include "libtest.h"
 
 typedef struct {
-  const char name[16];
+  char name[16];
   int32_t value;
 } foo_record_t;
 
@@ -40,8 +40,12 @@ EXTERN foo_record_t *
 foo_create(const char *name, int32_t value)
 {
   static foo_record_t self;
+  int i;
 
-  strcpy((char*)self.name, name);
+  for(i=0; i<16; i++)
+    self.name[i] = '\0';
+
+  strcpy(self.name, name);
   self.value = value;
 
   return &self;
@@ -51,6 +55,10 @@ EXTERN foo_record_t
 foo_value_create(const char *name, int32_t value)
 {
   foo_record_t self;
+  int i;
+
+  for(i=0; i<16; i++)
+    self.name[i] = '\0';
 
   strcpy(self.name, name);
   self.value = value;

--- a/t/type_record_value.t
+++ b/t/type_record_value.t
@@ -24,7 +24,7 @@ subtest 'is a reference' => sub {
   $ffi->type("record(FooRecord)" => 'foo_record_t');
   my $get_name  = $ffi->function( foo_value_get_name    => [ 'foo_record_t' ] => 'string' );
   my $get_value = $ffi->function( foo_value_get_value   => [ 'foo_record_t' ] => 'sint32' );
-  #my $create    = $ffi->function( foo_value_create      => [ 'string', 'sint32' ] => 'foo_record_t' ); # todo
+  my $create    = $ffi->function( foo_value_create      => [ 'string', 'sint32' ] => 'foo_record_t' ); # todo
 
   subtest 'argument' => sub {
 
@@ -52,6 +52,14 @@ subtest 'is a reference' => sub {
 
       is $get_name->call($rv), "hello";
       is $get_value->call($rv), 42;
+
+    };
+
+    subtest 'return value' => sub {
+
+      my $rv = $create->call("laters", 47);
+      is $rv->name,  "laters\0\0\0\0\0\0\0\0\0\0";
+      is $rv->value, 47;
 
     };
   };

--- a/t/type_record_value.t
+++ b/t/type_record_value.t
@@ -4,8 +4,11 @@ use Test::More;
 use FFI::Platypus;
 use FFI::CheckLib qw( find_lib );
 use FFI::Platypus::Memory qw( malloc free );
+use FFI::Platypus::ShareConfig;
 
 my $libtest = find_lib lib => 'test', symbol => 'f0', libpath => 't/ffi';
+
+my $return_ok = FFI::Platypus::ShareConfig->get('probe')->{recordvalue};
 
 {
   package
@@ -24,7 +27,6 @@ subtest 'is a reference' => sub {
   $ffi->type("record(FooRecord)" => 'foo_record_t');
   my $get_name  = $ffi->function( foo_value_get_name    => [ 'foo_record_t' ] => 'string' );
   my $get_value = $ffi->function( foo_value_get_value   => [ 'foo_record_t' ] => 'sint32' );
-  my $create    = $ffi->function( foo_value_create      => [ 'string', 'sint32' ] => 'foo_record_t' ); # todo
 
   subtest 'argument' => sub {
 
@@ -56,6 +58,11 @@ subtest 'is a reference' => sub {
     };
 
     subtest 'return value' => sub {
+
+      plan skip_all => 'test requires working return records-by-value'
+        unless $return_ok;
+
+      my $create    = $ffi->function( foo_value_create      => [ 'string', 'sint32' ] => 'foo_record_t' );
 
       my $rv = $create->call("laters", 47);
       is $rv->name,  "laters\0\0\0\0\0\0\0\0\0\0";

--- a/xs/Function.xs
+++ b/xs/Function.xs
@@ -27,6 +27,12 @@ new(class, platypus, address, abi, var_fixed_args, return_type, ...)
       croak("variadic functions are not supported by some combination of your libffi/compiler/platypus");
     }
 #endif
+#ifndef FFI_PL_PROBE_RECORDVALUE
+    if(return_type->type_code == FFI_PL_TYPE_RECORD_VALUE)
+    {
+      croak("returning record values is not supported by some combination of your libffi/compiler/platypus");
+    }
+#endif
     ffi_abi = abi == -1 ? FFI_DEFAULT_ABI : abi;
 
     for(i=0,extra_arguments=0; i<(items-6); i++)

--- a/xs/Function.xs
+++ b/xs/Function.xs
@@ -27,10 +27,6 @@ new(class, platypus, address, abi, var_fixed_args, return_type, ...)
       croak("variadic functions are not supported by some combination of your libffi/compiler/platypus");
     }
 #endif
-    if(return_type->type_code == FFI_PL_TYPE_RECORD_VALUE)
-    {
-      croak("todo record value as return type");
-    }
     ffi_abi = abi == -1 ? FFI_DEFAULT_ABI : abi;
 
     for(i=0,extra_arguments=0; i<(items-6); i++)
@@ -175,7 +171,6 @@ call(self, ...)
   PREINIT:
     int i, n, perl_arg_index;
     SV *arg;
-    ffi_pl_result result;
     ffi_pl_arguments *arguments;
     void **argument_pointers;
     dMY_CXT;


### PR DESCRIPTION
0.91 added support for pass-by-value records as arguments.  This PR seeks to do the same for return types.