### PR TITLE
update which versions of Perl that we test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
   include:
     - env: CIP_TAG=5.31
     - env: CIP_TAG=5.30
+    - env: CIP_TAG=5.30.0-stretch32
     - env: CIP_TAG=5.30 CIP_ENV=FFI_PLATYPUS_MEMORY_STRDUP_IMPL=ffi
     - env: CIP_TAG=5.30-threads
     - env: CIP_TAG=5.30-longdouble
@@ -33,16 +34,13 @@ jobs:
     - env: CIP_TAG=5.18
     - env: CIP_TAG=5.16
     - env: CIP_TAG=5.14
-    - env: CIP_TAG=5.14-threads
     - env: CIP_TAG=5.14-longdouble
     - env: CIP_TAG=5.12
     - env: CIP_TAG=5.10.1
-    - env: CIP_TAG=5.10.1-threads
     - env: CIP_TAG=5.10.0
     - env: CIP_TAG=5.10.0-threads
     - env: CIP_TAG=5.8.9
     - env: CIP_TAG=5.8.8
-    - env: CIP_TAG=5.8.8-threads
     - env: CIP_TAG=5.8.1
     - env: CIP_TAG=5.8.1-threads
   allow_failures:

--- a/maint/cip-test
+++ b/maint/cip-test
@@ -10,13 +10,6 @@ if perl -e 'exit ! ($] > 5.010)'; then
 
   cpanm -n local::lib
 
-  # workaround for rt128685.  These two lines
-  # can and should be removed once IO::Socket::SSL
-  # is unborked.  In so far as that is possible
-  # anyway.
-  cpanm -n Net::SSLeay
-  cpanm -n IO::Socket::SSL
-
   maint/cip-test-cpan FFI::Util
   maint/cip-test-cpan FFI::TinyCC
   maint/cip-test-cpan FFI::TinyCC::Inline

--- a/maint/cip-test
+++ b/maint/cip-test
@@ -6,7 +6,7 @@ make
 make test TEST_VERBOSE=1
 make install
 
-if perl -e 'exit ! ($] > 5.010)'; then
+if perl -e 'exit ! ($] > 5.016)'; then
 
   cpanm -n local::lib
 

--- a/maint/cip-test
+++ b/maint/cip-test
@@ -11,8 +11,8 @@ if perl -e 'exit ! ($] > 5.016)'; then
   cpanm -n local::lib
 
   maint/cip-test-cpan FFI::Util
-  maint/cip-test-cpan FFI::TinyCC
-  maint/cip-test-cpan FFI::TinyCC::Inline
+  #maint/cip-test-cpan FFI::TinyCC
+  #maint/cip-test-cpan FFI::TinyCC::Inline
   maint/cip-test-cpan FFI::ExtractSymbols
 
   maint/cip-test-cpan UUID::FFI


### PR DESCRIPTION
 - add stretch32 because the only other 32bit testing in CI is done on windows, which is difficult to debug sometimes, and doesn't always support everything that we do on Linux
 - remove some older threaded Perls.  We are testing a LOT of different versions.  We will keep the latest version with threads (5.30 as of this writing), the oldest version (5.8.1) and known buggy version (allow fail 5.10.0)

- Also: remove `FFI::TinyCC` from the downstream deps to test for regressions.  It has become pretty unreliable.