### PR TITLE
Allow decoration of record value type with * to get a pointer

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - You can now decorate record value types with * to get
+    a record type using type parse 1 (gh#150)
 
 0.94      2019-07-23 09:53:46 -0400
   - Production release identical to 0.93_03

--- a/lib/FFI/Platypus/TypeParser/Version1.pm
+++ b/lib/FFI/Platypus/TypeParser/Version1.pm
@@ -222,6 +222,16 @@ sub parse
     if(my $pointer = $8)
     {
       my $unit_type = $self->parse($unit_name, $opt);
+
+      if($unit_type->is_record_value)
+      {
+        my $meta = $unit_type->meta;
+        return $self->types->{$name} = $self->create_type_record(
+          $meta->{size},
+          $meta->{class},
+        );
+      }
+
       my $basic_name = $self->global_types->{rev}->{$unit_type->type_code};
       if($basic_name)
       {

--- a/t/ffi_platypus_typeparser_version1.t
+++ b/t/ffi_platypus_typeparser_version1.t
@@ -362,7 +362,7 @@ subtest 'record class' => sub {
     package Foo::Bar5;
     use FFI::Platypus::Record;
     record_layout(qw(
-      int foo
+      string(67) foo
     ));
   }
 
@@ -379,6 +379,24 @@ subtest 'record class' => sub {
     }
 
   };
+
+  subtest 'alias' => sub {
+
+    local $@ = '';
+    my $check = eval { $tp->check_alias('foo_bar5_t') };
+    is "$@", "";
+    is $check, 1;
+
+    eval { $tp->set_alias('foo_bar5_t', $tp->parse('record(Foo::Bar5)') ) };
+    is "$@", "";
+
+    is $tp->parse('foo_bar5_t')->type_code, FFI_PL_TYPE_RECORD_VALUE;
+
+    is $tp->parse('foo_bar5_t*')->type_code, FFI_PL_TYPE_RECORD;
+    is $tp->parse('foo_bar5_t*')->sizeof, 67;
+
+  };
+
 
 };
 

--- a/xs/Type.xs
+++ b/xs/Type.xs
@@ -61,6 +61,14 @@ is_record(self)
     RETVAL
 
 int
+is_record_value(self)
+    ffi_pl_type *self
+  CODE:
+    RETVAL = self->type_code == FFI_PL_TYPE_RECORD_VALUE;
+  OUTPUT:
+    RETVAL
+
+int
 is_ro(self)
     ffi_pl_type *self
   CODE:


### PR DESCRIPTION
The terminology is terrible.  But basically when you are using type parser 1, you can now decorate a record value with the `*` character to get a pointer to record type.

```perl
  $ffi->type('record(Foo::Bar)' => 'foo_bar_t');
  $ffi->type('foo_bar_t*');  # same as record(Foo::Bar)*
```