### PR TITLE
add a bad check for forks.pm

### DIFF
--- a/inc/bad-forks.pl
+++ b/inc/bad-forks.pl
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use File::Spec;
+
+my $path;
+foreach my $inc (@INC)
+{
+  $path = File::Spec->catfile($inc, 'forks.pm');
+  last if -f $path;
+}
+
+if(-f $path)
+{
+  eval q{ use forks };
+  print "There seems to be something wrong with your forks.pm module.\n";
+  print "This exception was raised when trying to use forks:\n\n";
+
+  print "  $@\n\n";
+
+  print "Although forks.pm is not required by FFI-Platypus, it does test\n";
+  print "against forks.pm if it is installed, so please fix your forks.pm\n";
+  print "before trying to install FFI-Platypus.\n\n";
+
+  print "If you believe this to be an error in FFI-Platypus, please feel\n";
+  print "free to open a ticket here:\n\n";
+
+  print "https://github.com/Perl5-FFI/FFI-Platypus/issues\n\n";
+  exit 2 if $@;
+}

--- a/inc/mymm.pl
+++ b/inc/mymm.pl
@@ -24,7 +24,7 @@ use Capture::Tiny qw( capture_merged );
       system $^X, $badcheck;
       $?;
     };
-    if($?)
+    if($ret)
     {
       if($out ne '')
       {


### PR DESCRIPTION
This is to avoid bogus cpantesters results like this:

```
Not a HASH reference at /home/syber/perl5/perlbrew/perls/5.26.3/lib/site_perl/5.26.3/x86_64-linux/forks.pm line 121.
BEGIN failed--compilation aborted at /home/syber/perl5/perlbrew/perls/5.26.3/lib/site_perl/5.26.3/x86_64-linux/forks.pm line 122.
Compilation failed in require at t/forks.t line 20.
BEGIN failed--compilation aborted at t/forks.t line 20.
Undefined subroutine &threads::_END called at (eval 64) line 1.
END failed--call queue aborted at t/forks.t line 20.
t/forks.t ................................ 
Dubious, test returned 22 (wstat 5632, 0x1600)
No subtests run 
```

I've sent the tester in question an email, but if I don't hear back I will merge this and cut a release.