### PR TITLE
Small correction to POD in FFI/Platypus/Type.pm

### DIFF
--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -434,7 +434,7 @@ and return an opaque pointer to the string using a cast.
  my $get_message => $ffi->closure(sub {
    our $message = "my message";  # needs to be our so that it doesn't
                                  # get free'd
-   my $ptr = $ffi->cast('string' => 'opaque');
+   my $ptr = $ffi->cast('string' => 'opaque', $message);
    return $ptr;
  });
  print_message($get_message);

--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -374,7 +374,7 @@ a string and then free it.
  $ffi->attach( get_string => [] => 'opaque' );
  $ffi->attach( free_string => ['opaque'] => 'void' );
  my $ptr = get_string();
- my $str = $ffi->cast( 'opaque' => 'string' );  # copies the string
+ my $str = $ffi->cast( 'opaque' => 'string', $ptr );  # copies the string
  free_string($ptr);
 
 If you are doing this sort of thing a lot, it can be worth adding a
@@ -385,7 +385,7 @@ custom type:
    native_type => 'opaque',
    native_to_perl => sub {
      my($ptr) = @_;
-     my $str = $ffi->cast( 'opaque' => 'string' ); # copies the string
+     my $str = $ffi->cast( 'opaque' => 'string', $ptr ); # copies the string
      free_string($ptr);
    }
  });


### PR DESCRIPTION
Fixed typo in POD section "Strings" in `FFI/Platypus/Type.pm`.
The `cast()` method takes a third required parameter "original_value"
which was missing.