### PR TITLE
Update documentation for version 1.00

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Convert documentation from api => 0 (implicit) to api => 1 (explicit)
   - Improved documentation (gh#181, gh#184)
 
 0.98      2019-10-14 13:18:02 -0600

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Improved documentation (gh#181, gh#184)
 
 0.98      2019-10-14 13:18:02 -0600
   - Production release identical to 0.97_05

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ to Platypus or FFI, you may want to skip down to the
 Platypus has extensive documentation of types at [FFI::Platypus::Type](https://metacpan.org/pod/FFI::Platypus::Type)
 and its custom types API at [FFI::Platypus::API](https://metacpan.org/pod/FFI::Platypus::API).
 
+You are **strongly** encouraged to use API level 1 for all new code.
+There are a number of improvements and design fixes that you get
+for free.  You should even consider updating existing modules to
+use API level 1 where feasible.  How do I do that you might ask?
+Simply pass in the API level to the platypus constructor.
+
+    my $ffi = FFI::Platypus->new( api => 1 );
+
+The Platypus documentation has already been updated to assume API
+level 1.
+
 # CONSTRUCTORS
 
 ## new

--- a/README.md
+++ b/README.md
@@ -522,18 +522,6 @@ prerequisites appropriately.
 
 Return the address of the given symbol (usually function).
 
-## package
-
-\[version 0.15 api = 0\]
-
-    $ffi->package($package, $file); # usually __PACKAGE__ and __FILE__ can be used
-    $ffi->package;                  # autodetect
-
-If you use [FFI::Build](https://metacpan.org/pod/FFI::Build) (or the older deprecated [Module::Build::FFI](https://metacpan.org/pod/Module::Build::FFI)
-to bundle C code with your distribution, you can use this method to tell
-the [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus) instance to look for symbols that came with the
-dynamic library that was built when your distribution was installed.
-
 ## bundle
 
 \[version 0.96 api = 1+\]
@@ -543,9 +531,24 @@ dynamic library that was built when your distribution was installed.
     $ffi->bundle($package);
     $ffi->bundle;
 
-This is a new experimental interface for bundling compiled code with your
+This is an interface for bundling compiled code with your
 distribution intended to eventually replace the `package` method documented
 above.  See [FFI::Platypus::Bundle](https://metacpan.org/pod/FFI::Platypus::Bundle) for details on how this works.
+
+## package
+
+\[version 0.15 api = 0\]
+
+    $ffi->package($package, $file); # usually __PACKAGE__ and __FILE__ can be used
+    $ffi->package;                  # autodetect
+
+**Note**: This method is officially discouraged in favor of `bundle`
+described above.
+
+If you use [FFI::Build](https://metacpan.org/pod/FFI::Build) (or the older deprecated [Module::Build::FFI](https://metacpan.org/pod/Module::Build::FFI)
+to bundle C code with your distribution, you can use this method to tell
+the [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus) instance to look for symbols that came with the
+dynamic library that was built when your distribution was installed.
 
 ## abis
 
@@ -963,7 +966,7 @@ implemented using FFI called [ZMQ::FFI](https://metacpan.org/pod/ZMQ::FFI).
     # the ArchiveWrite class that could be used for writing archive formats
     # supported by libarchive
     
-    my $ffi = FFI::Platypus->new( api => 1, experimental => 1);
+    my $ffi = FFI::Platypus->new( api => 1 );
     $ffi->lib(find_lib_or_exit lib => 'archive');
     $ffi->type('object(Archive)'      => 'archive_t');
     $ffi->type('object(ArchiveRead)'  => 'archive_read_t');
@@ -1093,7 +1096,7 @@ Rather than this:
       use constant OUT => bless \do { my $out=1 }, __PACKAGE__;
       use constant ERR => bless \do { my $err=2 }, __PACKAGE__;
     
-      my $ffi = FFI::Platypus->new( api => 1, experimental => 1, lib => [undef]);
+      my $ffi = FFI::Platypus->new( api => 1, lib => [undef]);
     
       $ffi->type('object(FD,int)' => 'fd');
     

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Write Perl bindings to non-Perl libraries with FFI. No XS required.
 
     use FFI::Platypus;
     
-    my $ffi = FFI::Platypus->new;
+    # for all new code you should use api => 1
+    my $ffi = FFI::Platypus->new( api => 1 );
     $ffi->lib(undef); # search libc
     
     # call dynamically
@@ -95,7 +96,7 @@ and its custom types API at [FFI::Platypus::API](https://metacpan.org/pod/FFI::P
 
 ## new
 
-    my $ffi = FFI::Platypus->new(%options);
+    my $ffi = FFI::Platypus->new( api => 1, %options);
 
 Create a new instance of [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus).
 
@@ -122,6 +123,9 @@ the [lib](#lib) attribute.
         Enable the next generation type parser which allows pass-by-value records
         and type decoration on basic types.  Using API level 1 prior to Platypus
         version 1.00 will trigger a (noisy) warning.
+
+        All new code should be written with `api =` 1>!  The Platypus documentation
+        assumes this api level is set.
 
 - lib
 
@@ -227,9 +231,9 @@ definitions.
 
 Examples:
 
-    $ffi->type('sint32'); # oly checks to see that sint32 is a valid type
+    $ffi->type('sint32');            # oly checks to see that sint32 is a valid type
     $ffi->type('sint32' => 'myint'); # creates an alias myint for sint32
-    $ffi->type('bogus'); # dies with appropriate diagnostic
+    $ffi->type('bogus');             # dies with appropriate diagnostic
 
 ## custom\_type
 
@@ -574,7 +578,7 @@ that are related to types.
 
     use FFI::Platypus;
     
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     $ffi->lib(undef);
     
     $ffi->attach(puts => ['string'] => 'int');
@@ -598,7 +602,7 @@ includes the standard c library.
     # in the old version, and am not really familiar with the libnotify API to
     # say what is the cause.  Patches welcome to fix it.
     
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     $ffi->lib(find_lib_or_exit lib => 'notify');
     
     $ffi->attach(notify_init   => ['string'] => 'void');
@@ -651,7 +655,7 @@ We are really calling the C function `notify_notification_new`.
     use FFI::Platypus;
     use FFI::Platypus::Memory qw( malloc free memcpy );
     
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     my $buffer = malloc 12;
     
     memcpy $buffer, $ffi->cast('string' => 'opaque', "hello there"), length "hello there\0";
@@ -685,10 +689,10 @@ these and other memory related functions are provided by the
         string tm_zone
     ));
     
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     $ffi->lib(undef);
     # define a record class My::UnixTime and alias it to "tm"
-    $ffi->type("record(My::UnixTime)" => 'tm');
+    $ffi->type("record(My::UnixTime)*" => 'tm');
     
     # attach the C localtime function as a constructor
     $ffi->attach( localtime => ['time_t*'] => 'tm', sub {
@@ -717,16 +721,21 @@ specific layout.  For more details see [FFI::Platypus::Record](https://metacpan.
 ([FFI::Platypus::Type](https://metacpan.org/pod/FFI::Platypus::Type) includes some other ways of manipulating
 structured data records).
 
+The C `localtime` function takes a pointer to a record, hence we suffix
+the type with a star: `record(My::UnixTime)*`.  If the function takes
+a record in pass-by-value mode then we'd just say `record(My::UnixTime)`
+with no star suffix.
+
 ## libuuid
 
     use FFI::CheckLib;
     use FFI::Platypus;
     use FFI::Platypus::Memory qw( malloc free );
     
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     $ffi->lib(find_lib_or_exit lib => 'uuid');
-    $ffi->type('string(37)' => 'uuid_string');
-    $ffi->type('record(16)' => 'uuid_t');
+    $ffi->type('string(37)*' => 'uuid_string');
+    $ffi->type('record(16)*' => 'uuid_t');
     
     $ffi->attach(uuid_generate => ['uuid_t'] => 'void');
     $ffi->attach(uuid_unparse  => ['uuid_t','uuid_string'] => 'void');
@@ -753,7 +762,7 @@ this case it is simply 16 bytes).  We also know that the strings
 
     use FFI::Platypus;
     
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     $ffi->lib(undef);
     
     $ffi->attach(puts => ['string'] => 'int');
@@ -769,7 +778,7 @@ this case it is simply 16 bytes).  We also know that the strings
     use FFI::Platypus;
     use FFI::CheckLib;
     
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     $ffi->lib(undef);
     $ffi->attach(puts => ['string'] => 'int');
     $ffi->attach(fdim => ['double','double'] => 'double');
@@ -822,7 +831,7 @@ handled seamlessly by Platypus.
     use FFI::TinyCC;
     use FFI::Platypus;
     
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     my $tcc = FFI::TinyCC->new;
     
     $tcc->compile_string(q{
@@ -862,7 +871,7 @@ just-in-time (JIT) compilation service for FFI.
     use FFI::Platypus::Buffer qw( scalar_to_buffer buffer_to_scalar );
     
     my $endpoint = "ipc://zmq-ffi-$$";
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     
     $ffi->lib(undef); # for puts
     $ffi->attach(puts => ['string'] => 'int');
@@ -947,82 +956,71 @@ implemented using FFI called [ZMQ::FFI](https://metacpan.org/pod/ZMQ::FFI).
 ## libarchive
 
     use FFI::Platypus      ();
-    use FFI::Platypus::API ();
-    use FFI::CheckLib      ();
+    use FFI::CheckLib      qw( find_lib_or_exit );
     
     # This example uses FreeBSD's libarchive to list the contents of any
     # archive format that it suppors.  We've also filled out a part of
     # the ArchiveWrite class that could be used for writing archive formats
     # supported by libarchive
     
-    my $ffi = My::Platypus->new;
-    $ffi->lib(FFI::CheckLib::find_lib_or_exit lib => 'archive');
-    
-    $ffi->custom_type(archive => {
-      native_type    => 'opaque',
-      perl_to_native => sub { ${$_[0]} },
-      native_to_perl => sub {
-        # this works because archive_read_new ignores any arguments
-        # and we pass in the class name which we can get here.
-        my $class = FFI::Platypus::API::arguments_get_string(0);
-        bless \$_[0], $class;
-      },
-    });
-    
-    $ffi->custom_type(archive_entry => {
-      native_type => 'opaque',
-      perl_to_native => sub { ${$_[0]} },
-      native_to_perl => sub {
-        # works likewise for archive_entry objects
-        my $class = FFI::Platypus::API::arguments_get_string(0);
-        bless \$_[0], $class,
-      },
-    });
-    
-    package My::Platypus;
-    
-    use base qw( FFI::Platypus );
-    
-    sub find_symbol
-    {
-      my($self, $name) = @_;
-      my $prefix = lcfirst caller(2);
-      $prefix =~ s{([A-Z])}{"_" . lc $1}eg;
-      $self->SUPER::find_symbol(join '_', $prefix, $name);
-    }
+    my $ffi = FFI::Platypus->new( api => 1, experimental => 1);
+    $ffi->lib(find_lib_or_exit lib => 'archive');
+    $ffi->type('object(Archive)'      => 'archive_t');
+    $ffi->type('object(ArchiveRead)'  => 'archive_read_t');
+    $ffi->type('object(ArchiveWrite)' => 'archive_write_t');
+    $ffi->type('object(ArchiveEntry)' => 'archive_entry_t');
     
     package Archive;
     
     # base class is "abstract" having no constructor or destructor
     
-    $ffi->attach( error_string => ['archive'] => 'string' );
+    $ffi->mangler(sub {
+      my($name) = @_;
+      "archive_$name";
+    });
+    $ffi->attach( error_string => ['archive_t'] => 'string' );
     
     package ArchiveRead;
     
     our @ISA = qw( Archive );
     
-    $ffi->attach( new                   => ['string']                    => 'archive' );
-    $ffi->attach( [ free => 'DESTROY' ] => ['archive']                   => 'void' );
-    $ffi->attach( support_filter_all    => ['archive']                   => 'int' );
-    $ffi->attach( support_format_all    => ['archive']                   => 'int' );
-    $ffi->attach( open_filename         => ['archive','string','size_t'] => 'int' );
-    $ffi->attach( next_header2          => ['archive', 'archive_entry' ] => 'int' );
-    $ffi->attach( data_skip             => ['archive']                   => 'int' );
+    $ffi->mangler(sub {
+      my($name) = @_;
+      "archive_read_$name";
+    });
+    
+    $ffi->attach( new                   => ['string']                        => 'archive_read_t' );
+    $ffi->attach( [ free => 'DESTROY' ] => ['archive_t']                     => 'void' );
+    $ffi->attach( support_filter_all    => ['archive_t']                     => 'int' );
+    $ffi->attach( support_format_all    => ['archive_t']                     => 'int' );
+    $ffi->attach( open_filename         => ['archive_t','string','size_t']   => 'int' );
+    $ffi->attach( next_header2          => ['archive_t', 'archive_entry_t' ] => 'int' );
+    $ffi->attach( data_skip             => ['archive_t']                     => 'int' );
     # ... define additional read methods
     
     package ArchiveWrite;
     
     our @ISA = qw( Archive );
     
-    $ffi->attach( new                   => ['string'] => 'archive' );
-    $ffi->attach( [ free => 'DESTROY' ] => ['archive'] => 'void' );
+    $ffi->mangler(sub {
+      my($name) = @_;
+      "archive_write_$name";
+    });
+    
+    $ffi->attach( new                   => ['string'] => 'archive_write_t' );
+    $ffi->attach( [ free => 'DESTROY' ] => ['archive_write_t'] => 'void' );
     # ... define additional write methods
     
     package ArchiveEntry;
     
-    $ffi->attach( new => ['string']     => 'archive_entry' );
-    $ffi->attach( [ free => 'DESTROY' ] => ['archive_entry'] => 'void' );
-    $ffi->attach( pathname              => ['archive_entry'] => 'string' );
+    $ffi->mangler(sub {
+      my($name) = @_;
+      "archive_entry_$name";
+    });
+    
+    $ffi->attach( new => ['string']     => 'archive_entry_t' );
+    $ffi->attach( [ free => 'DESTROY' ] => ['archive_entry_t'] => 'void' );
+    $ffi->attach( pathname              => ['archive_entry_t'] => 'string' );
     # ... define additional entry methods
     
     package main;
@@ -1063,26 +1061,72 @@ object oriented interface via opaque pointers.  This example creates an
 abstract class `Archive`, and concrete classes `ArchiveWrite`,
 `ArchiveRead` and `ArchiveEntry`.  The concrete classes can even be
 inherited from and extended just like any Perl classes because of the
-way the custom types are implemented.  For more details on custom types
-see [FFI::Platypus::Type](https://metacpan.org/pod/FFI::Platypus::Type) and [FFI::Platypus::API](https://metacpan.org/pod/FFI::Platypus::API).
+way the custom types are implemented.  We use Platypus's `object`
+type for this implementation, which is a wrapper around an `opaque`
+(can also be an integer) type that is blessed into a particular class.
 
-Another advanced feature of this example is that we extend the
-[FFI::Platypus](https://metacpan.org/pod/FFI::Platypus) class to define our own find\_symbol method that
-prefixes the symbol names depending on the class in which they are
-defined. This means we can do this when we define a method for Archive:
+Another advanced feature of this example is that we define a mangler
+to modify the symbol resolution for each class.  This means we can do
+this when we define a method for Archive:
 
-    $ffi->attach( support_filter_all => ['archive'] => 'int' );
+    $ffi->attach( support_filter_all => ['archive_t'] => 'int' );
 
 Rather than this:
 
     $ffi->attach(
       [ archive_read_support_filter_all => 'support_read_filter_all' ] =>
-      ['archive'] => 'int' );
+      ['archive_t'] => 'int' );
     );
 
-If you didn't want to create an entire new class just for this little
-trick you could also use something like [Object::Method](https://metacpan.org/pod/Object::Method) to extend
-`find_symbol`.
+## unix open
+
+    use FFI::Platypus;
+    
+    {
+      package FD;
+    
+      use constant O_RDONLY => 0;
+      use constant O_WRONLY => 1;
+      use constant O_RDWR   => 2;
+    
+      use constant IN  => bless \do { my $in=0  }, __PACKAGE__;
+      use constant OUT => bless \do { my $out=1 }, __PACKAGE__;
+      use constant ERR => bless \do { my $err=2 }, __PACKAGE__;
+    
+      my $ffi = FFI::Platypus->new( api => 1, experimental => 1, lib => [undef]);
+    
+      $ffi->type('object(FD,int)' => 'fd');
+    
+      $ffi->attach( [ 'open' => 'new' ] => [ 'string', 'int', 'mode_t' ] => 'fd' => sub {
+        my($xsub, $class, $fn, @rest) = @_;
+        my $fd = $xsub->($fn, @rest);
+        die "error opening $fn $!" if $$fd == -1;
+        $fd;
+      });
+    
+      $ffi->attach( write => ['fd', 'string', 'size_t' ] => 'ssize_t' );
+      $ffi->attach( read  => ['fd', 'string', 'size_t' ] => 'ssize_t' );
+      $ffi->attach( close => ['fd'] => 'int' );
+    }
+    
+    my $fd = FD->new("$0", FD::O_RDONLY);
+    
+    my $buffer = "\0" x 10;
+    
+    while(my $br = $fd->read($buffer, 10))
+    {
+      FD::OUT->write($buffer, $br);
+    }
+    
+    $fd->close;
+
+**Discussion**: The Unix file system calls use an integer handle for
+each open file.  We can use the same `object` type that we used
+for libarchive above, except we let platypus know that the underlying
+type is `int` instead of `opaque` (the latter being the default for
+the `object` type).  Mainly just for demonstration since Perl has much
+better IO libraries, but now we have an OO interface to the Unix IO
+functions.
 
 ## bzip2
 
@@ -1091,7 +1135,7 @@ trick you could also use something like [Object::Method](https://metacpan.org/po
     use FFI::Platypus::Buffer qw( scalar_to_buffer buffer_to_scalar );
     use FFI::Platypus::Memory qw( malloc free );
     
-    my $ffi = FFI::Platypus->new;
+    my $ffi = FFI::Platypus->new( api => 1 );
     $ffi->lib(find_lib_or_die lib => 'bz2');
     
     $ffi->attach(

--- a/README.md
+++ b/README.md
@@ -1345,6 +1345,8 @@ different types.  The enum _values_ are essentially the same as macro constants
 described above from an FFI perspective.  Thus the process of defining enum values
 is identical to the process of defining macro constants in Perl.
 
+For more details on enumerated types see ["Enum types" in FFI::Platypus::Type](https://metacpan.org/pod/FFI::Platypus::Type#Enum-types).
+
 ## I get seg faults on some platforms but not others with a library using pthreads.
 
 On some platforms, Perl isn't linked with `libpthreads` if Perl threads are not

--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,21 @@ a tool ([Convert::Binary::C](https://metacpan.org/pod/Convert::Binary::C) can do
 
 See also the "Integer constants" example in [FFI::Platypus::Type](https://metacpan.org/pod/FFI::Platypus::Type).
 
+You can also use the new Platypus bundle interface to define Perl constants
+from C space.  This is more reliable, but does require a compiler.  It is
+recommended mainly for writing bindings against libraries that have constants
+that can vary widely from platform to platform.  See [FFI::Platypus::Constant](https://metacpan.org/pod/FFI::Platypus::Constant)
+for details.
+
+## What about enums?
+
+The C enum types are integers.  The underlying type is up to the platform, so
+Platypus provides `enum` and `senum` types for unsigned and singed enums
+respectively.  At least some compilers treat signed and unsigned enums as
+different types.  The enum _values_ are essentially the same as macro constants
+described above from an FFI perspective.  Thus the process of defining enum values
+is identical to the process of defining macro constants in Perl.
+
 ## I get seg faults on some platforms but not others with a library using pthreads.
 
 On some platforms, Perl isn't linked with `libpthreads` if Perl threads are not

--- a/README.md
+++ b/README.md
@@ -1567,10 +1567,6 @@ the development package for `libffi` as prereqs for this module.
 
     Find dynamic libraries in a portable way.
 
-- [Module::Build::FFI](https://metacpan.org/pod/Module::Build::FFI)
-
-    Bundle C code with your FFI extension.
-
 - [FFI::TinyCC](https://metacpan.org/pod/FFI::TinyCC)
 
     JIT compiler for FFI.

--- a/author.yml
+++ b/author.yml
@@ -126,6 +126,7 @@ pod_spelling_system:
     - HAKONH
     - hakonhagland
     - kon
+    - merrilymeredith
 
 pod_coverage:
   skip: 0

--- a/corpus/memory/return_pointer.pl
+++ b/corpus/memory/return_pointer.pl
@@ -40,7 +40,7 @@ subtest 'string' => sub {
   my $f = $ffi->function(0 => [ 'opaque' ] => 'string*' );
 
   my $ptr = strdup("hello world");
-  
+
   no_leaks_ok { $f->call($ptr) };
   no_leaks_ok { $f->call(undef) };
 

--- a/examples/archive_object.pl
+++ b/examples/archive_object.pl
@@ -8,7 +8,7 @@ use FFI::CheckLib      qw( find_lib_or_exit );
 # the ArchiveWrite class that could be used for writing archive formats
 # supported by libarchive
 
-my $ffi = FFI::Platypus->new( api => 1, experimental => 1);
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(find_lib_or_exit lib => 'archive');
 $ffi->type('object(Archive)'      => 'archive_t');
 $ffi->type('object(ArchiveRead)'  => 'archive_read_t');

--- a/examples/attach_from_pointer.pl
+++ b/examples/attach_from_pointer.pl
@@ -3,7 +3,7 @@ use warnings;
 use FFI::TinyCC;
 use FFI::Platypus;
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 my $tcc = FFI::TinyCC->new;
 
 $tcc->compile_string(q{

--- a/examples/bzip2.pl
+++ b/examples/bzip2.pl
@@ -5,7 +5,7 @@ use FFI::CheckLib qw( find_lib_or_die );
 use FFI::Platypus::Buffer qw( scalar_to_buffer buffer_to_scalar );
 use FFI::Platypus::Memory qw( malloc free );
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(find_lib_or_die lib => 'bz2');
 
 $ffi->attach(

--- a/examples/closure-opaque.pl
+++ b/examples/closure-opaque.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use FFI::Platypus;
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib('./closure.so');
 $ffi->type('(int)->int' => 'closure_t');
 

--- a/examples/closure.pl
+++ b/examples/closure.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use FFI::Platypus;
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib('./closure.so');
 $ffi->type('(int)->int' => 'closure_t');
 

--- a/examples/file_handle.pl
+++ b/examples/file_handle.pl
@@ -13,7 +13,7 @@ use FFI::Platypus;
   use constant OUT => bless \do { my $out=1 }, __PACKAGE__;
   use constant ERR => bless \do { my $err=2 }, __PACKAGE__;
 
-  my $ffi = FFI::Platypus->new( api => 1, experimental => 1, lib => [undef]);
+  my $ffi = FFI::Platypus->new( api => 1, lib => [undef]);
 
   $ffi->type('object(FD,int)' => 'fd');
 

--- a/examples/getpid.pl
+++ b/examples/getpid.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use FFI::Platypus;
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(undef);
 
 $ffi->attach(puts => ['string'] => 'int');

--- a/examples/integer.pl
+++ b/examples/integer.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use FFI::Platypus;
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(undef);
 
 $ffi->attach(puts => ['string'] => 'int');

--- a/examples/malloc.pl
+++ b/examples/malloc.pl
@@ -3,7 +3,7 @@ use warnings;
 use FFI::Platypus;
 use FFI::Platypus::Memory qw( malloc free memcpy );
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 my $buffer = malloc 12;
 
 memcpy $buffer, $ffi->cast('string' => 'opaque', "hello there"), length "hello there\0";

--- a/examples/math.pl
+++ b/examples/math.pl
@@ -3,7 +3,7 @@ use warnings;
 use FFI::Platypus;
 use FFI::CheckLib;
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(undef);
 $ffi->attach(puts => ['string'] => 'int');
 $ffi->attach(fdim => ['double','double'] => 'double');

--- a/examples/notify.pl
+++ b/examples/notify.pl
@@ -8,7 +8,7 @@ use FFI::Platypus;
 # in the old version, and am not really familiar with the libnotify API to
 # say what is the cause.  Patches welcome to fix it.
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(find_lib_or_exit lib => 'notify');
 
 $ffi->attach(notify_init   => ['string'] => 'void');

--- a/examples/pipe.pl
+++ b/examples/pipe.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use FFI::Platypus;
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(undef);
 $ffi->attach([pipe=>'mypipe'] => ['int[2]'] => 'int');
 

--- a/examples/time.pl
+++ b/examples/time.pl
@@ -35,9 +35,9 @@ my $tm_size = $c->sizeof("tm");
 
 # create the Platypus instance and create the appropriate
 # types and functions
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(undef);
-$ffi->type("record($tm_size)" => 'tm');
+$ffi->type("record($tm_size)*" => 'tm');
 $ffi->attach( [ localtime => 'my_localtime' ] => ['time_t*'] => 'tm'     );
 $ffi->attach( [ time      => 'my_time'      ] => ['tm']      => 'time_t' );
 

--- a/examples/time_oo.pl
+++ b/examples/time_oo.pl
@@ -42,11 +42,11 @@ my $tm_size = tcc_eval qq{
 # be defined before you try to define it as a type.
 sub _ffi_record_size { $tm_size };
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(undef);
 # define a record class My::UnixTime and alias it
 # to "tm"
-$ffi->type("record(My::UnixTime)" => 'tm');
+$ffi->type("record(My::UnixTime)*" => 'tm');
 
 # attach the C localtime function as a constructor
 $ffi->attach( [ localtime => '_new' ] => ['time_t*'] => 'tm' );

--- a/examples/time_record.pl
+++ b/examples/time_record.pl
@@ -19,10 +19,10 @@ record_layout(qw(
     string tm_zone
 ));
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(undef);
 # define a record class My::UnixTime and alias it to "tm"
-$ffi->type("record(My::UnixTime)" => 'tm');
+$ffi->type("record(My::UnixTime)*" => 'tm');
 
 # attach the C localtime function as a constructor
 $ffi->attach( localtime => ['time_t*'] => 'tm', sub {

--- a/examples/uuid.pl
+++ b/examples/uuid.pl
@@ -4,10 +4,10 @@ use FFI::CheckLib;
 use FFI::Platypus;
 use FFI::Platypus::Memory qw( malloc free );
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(find_lib_or_exit lib => 'uuid');
-$ffi->type('string(37)' => 'uuid_string');
-$ffi->type('record(16)' => 'uuid_t');
+$ffi->type('string(37)*' => 'uuid_string');
+$ffi->type('record(16)*' => 'uuid_t');
 
 $ffi->attach(uuid_generate => ['uuid_t'] => 'void');
 $ffi->attach(uuid_unparse  => ['uuid_t','uuid_string'] => 'void');

--- a/examples/var_array.pl
+++ b/examples/var_array.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use FFI::Platypus;
 
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 )
 $ffi->lib('./var_array.so');
 
 $ffi->attach( sum => [ 'int[]', 'int' ] => 'int' );

--- a/examples/zmq3.pl
+++ b/examples/zmq3.pl
@@ -10,7 +10,7 @@ use FFI::Platypus::Memory qw( malloc );
 use FFI::Platypus::Buffer qw( scalar_to_buffer buffer_to_scalar );
 
 my $endpoint = "ipc://zmq-ffi-$$";
-my $ffi = FFI::Platypus->new;
+my $ffi = FFI::Platypus->new( api => 1 );
 
 $ffi->lib(undef); # for puts
 $ffi->attach(puts => ['string'] => 'int');

--- a/lib/FFI/Build.pm
+++ b/lib/FFI/Build.pm
@@ -27,7 +27,7 @@ use File::Path ();
  # $lib is an instance of FFI::Build::File::Library
  my $lib = $build->build;
  
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  # The filename will be platform dependant, but something like libfrooble.so or frooble.dll
  $ffi->lib($lib->path);
  

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -1349,6 +1349,21 @@ a tool (L<Convert::Binary::C> can do this) that can extract the constants for yo
 
 See also the "Integer constants" example in L<FFI::Platypus::Type>.
 
+You can also use the new Platypus bundle interface to define Perl constants
+from C space.  This is more reliable, but does require a compiler.  It is
+recommended mainly for writing bindings against libraries that have constants
+that can vary widely from platform to platform.  See L<FFI::Platypus::Constant>
+for details.
+
+=head2 What about enums?
+
+The C enum types are integers.  The underlying type is up to the platform, so
+Platypus provides C<enum> and C<senum> types for unsigned and singed enums
+respectively.  At least some compilers treat signed and unsigned enums as
+different types.  The enum I<values> are essentially the same as macro constants
+described above from an FFI perspective.  Thus the process of defining enum values
+is identical to the process of defining macro constants in Perl.
+
 =head2 I get seg faults on some platforms but not others with a library using pthreads.
 
 On some platforms, Perl isn't linked with C<libpthreads> if Perl threads are not

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -1416,6 +1416,8 @@ different types.  The enum I<values> are essentially the same as macro constants
 described above from an FFI perspective.  Thus the process of defining enum values
 is identical to the process of defining macro constants in Perl.
 
+For more details on enumerated types see L<FFI::Platypus::Type/"Enum types">.
+
 =head2 I get seg faults on some platforms but not others with a library using pthreads.
 
 On some platforms, Perl isn't linked with C<libpthreads> if Perl threads are not

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -991,12 +991,37 @@ sub find_symbol
   return;
 }
 
+=head2 bundle
+
+[version 0.96 api = 1+]
+
+ $ffi->bundle($package, \@args);
+ $ffi->bundle(\@args);
+ $ffi->bundle($package);
+ $ffi->bundle;
+
+This is an interface for bundling compiled code with your
+distribution intended to eventually replace the C<package> method documented
+above.  See L<FFI::Platypus::Bundle> for details on how this works.
+
+=cut
+
+sub bundle
+{
+  croak "bundle method only available with api => 1 or better" if $_[0]->{api} < 1;
+  require FFI::Platypus::Bundle;
+  goto &_bundle;
+}
+
 =head2 package
 
 [version 0.15 api = 0]
 
  $ffi->package($package, $file); # usually __PACKAGE__ and __FILE__ can be used
  $ffi->package;                  # autodetect
+
+B<Note>: This method is officially discouraged in favor of C<bundle>
+described above.
 
 If you use L<FFI::Build> (or the older deprecated L<Module::Build::FFI>
 to bundle C code with your distribution, you can use this method to tell
@@ -1010,28 +1035,6 @@ sub package
   croak "package method only available with api => 0" if $_[0]->{api} > 0;
   require FFI::Platypus::Legacy;
   goto &_package;
-}
-
-=head2 bundle
-
-[version 0.96 api = 1+]
-
- $ffi->bundle($package, \@args);
- $ffi->bundle(\@args);
- $ffi->bundle($package);
- $ffi->bundle;
-
-This is a new experimental interface for bundling compiled code with your
-distribution intended to eventually replace the C<package> method documented
-above.  See L<FFI::Platypus::Bundle> for details on how this works.
-
-=cut
-
-sub bundle
-{
-  croak "bundle method only available with api => 1 or better" if $_[0]->{api} < 1;
-  require FFI::Platypus::Bundle;
-  goto &_bundle;
 }
 
 =head2 abis

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -1354,6 +1354,27 @@ will come in after that.  This allows you to modify / convert the
 arguments to conform to the C API.  What ever value you return from the
 wrapper function will be returned back to the original caller.
 
+=head2 bundle your own code
+
+C<ffi/foo.c>:
+
+# EXAMPLE: examples/bundle-foo/ffi/foo.c
+
+C<lib/Foo.pm>:
+
+# EXAMPLE: examples/bundle-foo/lib/Foo.pm
+
+You can bundle your own C (or other compiled language) code with your
+Perl extension.  Sometimes this is helpful for smoothing over the
+interface of a C library which is not very FFI friendly.  Sometimes
+you may want to write some code in C for a tight loop.  Either way,
+you can do this with the Platypus bundle interface.  See
+L<FFI::Platypus::Bundle> for more details.
+
+Also related is the bundle constant interface, which allows you to
+define Perl constants in C space.  See L<FFI::Platypus::Constant>
+for details.
+
 =head1 FAQ
 
 =head2 How do I get constants defined as macros in C header files

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -120,6 +120,17 @@ L<EXAMPLES|/EXAMPLES> to get a taste of what you can do with Platypus.
 Platypus has extensive documentation of types at L<FFI::Platypus::Type>
 and its custom types API at L<FFI::Platypus::API>.
 
+You are B<strongly> encouraged to use API level 1 for all new code.
+There are a number of improvements and design fixes that you get
+for free.  You should even consider updating existing modules to
+use API level 1 where feasible.  How do I do that you might ask?
+Simply pass in the API level to the platypus constructor.
+
+ my $ffi = FFI::Platypus->new( api => 1 );
+
+The Platypus documentation has already been updated to assume API
+level 1.
+
 =cut
 
 our @CARP_NOT = qw( FFI::Platypus::Declare FFI::Platypus::Record );

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -1664,10 +1664,6 @@ Memory functions for FFI.
 
 Find dynamic libraries in a portable way.
 
-=item L<Module::Build::FFI>
-
-Bundle C code with your FFI extension.
-
 =item L<FFI::TinyCC>
 
 JIT compiler for FFI.

--- a/lib/FFI/Platypus/Closure.pm
+++ b/lib/FFI/Platypus/Closure.pm
@@ -23,7 +23,7 @@ create closure with OO interface
 create closure from Platypus object
 
  use FFI::Platypus;
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  my $closure = $ffi->closure(sub { print "hello world\n" });
 
 use closure

--- a/lib/FFI/Platypus/Constant.pm
+++ b/lib/FFI/Platypus/Constant.pm
@@ -10,6 +10,8 @@ use FFI::Platypus;
 
 =head1 SYNOPSIS
 
+C<ffi/foo.c>:
+
  #include <ffi_platypus_bundle.h>
  
  void
@@ -18,6 +20,21 @@ use FFI::Platypus;
    c->set_str("FOO", "BAR");       /* sets $package::FOO to "BAR" */
    c->set_str("ABC::DEF", "GHI");  /* sets ABC::DEF to GHI        */
  }
+
+C<lib/Foo.pm>:
+
+ package Foo;
+ 
+ use strict;
+ use warnings;
+ use FFI::Platypus;
+ use base qw( Exporter );
+ 
+ my $ffi = FFI::Platypus->new;
+ # sets constatns Foo::FOO and ABC::DEF from C
+ $ffi->bundle;
+ 
+ 1;
 
 =head1 DESCRIPTION
 

--- a/lib/FFI/Platypus/DL.pm
+++ b/lib/FFI/Platypus/DL.pm
@@ -19,7 +19,7 @@ push @EXPORT, grep /RTLD_/, keys %FFI::Platypus::DL::;
  
  my $handle = dlopen("./libfoo.so", RTLD_PLATYPUS_DEFAULT);
  my $address = dlsym($handle, "my_function_named_foo");
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->function($address => [] => 'void')->call;
  dlclose($handle);
 

--- a/lib/FFI/Platypus/Function.pm
+++ b/lib/FFI/Platypus/Function.pm
@@ -12,7 +12,7 @@ use FFI::Platypus;
  use FFI::Platypus;
  
  # call directly
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  my $f = $ffi->function(puts => ['string'] => 'int');
  $f->call("hello there");
  

--- a/lib/FFI/Platypus/Lang/ASM.pm
+++ b/lib/FFI/Platypus/Lang/ASM.pm
@@ -9,7 +9,7 @@ use warnings;
 =head1 SYNOPSIS
 
  use FFI::Platypus;
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->lang('ASM');
 
 =head1 DESCRIPTION

--- a/lib/FFI/Platypus/Lang/C.pm
+++ b/lib/FFI/Platypus/Lang/C.pm
@@ -9,7 +9,7 @@ use warnings;
 =head1 SYNOPSIS
 
  use FFI::Platypus;
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->lang('C'); # the default
 
 =head1 DESCRIPTION

--- a/lib/FFI/Platypus/Lang/Win32.pm
+++ b/lib/FFI/Platypus/Lang/Win32.pm
@@ -10,7 +10,7 @@ use Config;
 =head1 SYNOPSIS
 
  use FFI::Platypus;
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->lang('Win32');
 
 =head1 DESCRIPTION

--- a/lib/FFI/Platypus/Record.pm
+++ b/lib/FFI/Platypus/Record.pm
@@ -221,7 +221,6 @@ sub record_layout_1
 {
   if(@_ % 2 == 0)
   {
-    $DB::single = 1;
     my $ffi = FFI::Platypus->new( api => 1 );
     unshift @_, $ffi;
     goto &record_layout;

--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -431,6 +431,25 @@ returns a NULL pointer, it will be translated back to C<undef>.
 There are a number of useful utility functions for dealing with opaque
 types in the L<FFI::Platypus::Memory> module.
 
+=head2 Objects
+
+Object types are thin wrappers around two native types: integer and
+C<opaque> types.  They are just blessed references around either of
+those two types so that methods can be defined on them, but when they
+get passed to a Platypus xsub they are converted into the native
+integer or C<opaque> types.  This type is most useful when a API
+provides an OO style interface with an integer or C<opaque> value
+acting as an instance of a class.  There are two detailed examples
+in the main Platypus documentation using libarchive and unix open:
+
+=over 4
+
+=item L<FFI::Platypus/libarchive>
+
+=item L<FFI::Platypus/"unix open">
+
+=back
+
 =head2 Strings
 
 From the CPU's perspective, strings are just pointers.  From Perl and

--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -146,7 +146,7 @@ on two different platforms:
  {
    $type->type('sint32' => 'foo_t');
  }
-
+ 
  # function foo takes 16 bit signed integer on Windows
  # and a 32 bit signed integer on Linux.
  $ffi->attach( foo => [ 'foo_t' ] => 'void' );

--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -423,7 +423,7 @@ It feels like this should be able to work:
  });
  print_message($get_message);
 
-If the type declaration for `get_message_t` were legal, then this
+If the type declaration for C<get_message_t> were legal, then this
 script would likely segfault or in the very least corrupt memory.
 The problem is that once C<"my message"> is returned from the closure
 Perl doesn't have a reference to it anymore and will free it.

--- a/lib/FFI/Platypus/Type/PointerSizeBuffer.pm
+++ b/lib/FFI/Platypus/Type/PointerSizeBuffer.pm
@@ -28,7 +28,7 @@ In your Platypus::FFI code:
 
  use FFI::Platypus;
  
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->load_custom_type('::PointerSizeBuffer' => 'buffer');
  
  $ffi->attach(function_with_buffer => ['buffer'] => 'void');
@@ -48,7 +48,7 @@ pass in a string scalar as a pointer / size buffer pair.
 my @stack;
 
 *arguments_set_size_t
-  = FFI::Platypus->new->sizeof('size_t') == 4
+  = FFI::Platypus->new( api => 1, experimental => 1 )->sizeof('size_t') == 4
   ? \&arguments_set_uint32
   : \&arguments_set_uint64;
 

--- a/lib/FFI/Platypus/Type/StringArray.pm
+++ b/lib/FFI/Platypus/Type/StringArray.pm
@@ -27,7 +27,7 @@ In your L<Platypus::FFI> code:
 
  use FFI::Platypus;
  
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->load_custom_type('::StringArray' => 'string_array');
  $ffi->load_custom_type('::StringArray' => 'string_5' => 5);
  
@@ -62,7 +62,7 @@ use constant _incantation =>
   $^O eq 'MSWin32' && $Config::Config{archname} =~ /MSWin32-x64/
   ? 'Q'
   : 'L!';
-use constant _size_of_pointer => FFI::Platypus->new->sizeof('opaque');
+use constant _size_of_pointer => FFI::Platypus->new( api => 1, experimental => 1 )->sizeof('opaque');
 use constant _pointer_buffer => "P" . _size_of_pointer;
 
 my @stack;
@@ -146,7 +146,7 @@ sub ffi_custom_type_api_1
       $array_pointer;
     };
 
-    my $pointer_buffer = "P@{[ FFI::Platypus->new->sizeof('opaque') * $count ]}";
+    my $pointer_buffer = "P@{[ FFI::Platypus->new( api => 1, experimental => 1 )->sizeof('opaque') * $count ]}";
     my $incantation_count = _incantation.$count;
 
     $config->{native_to_perl} = sub {

--- a/lib/FFI/Platypus/Type/StringPointer.pm
+++ b/lib/FFI/Platypus/Type/StringPointer.pm
@@ -28,7 +28,7 @@ In your Platypus::FFI code:
 
  use FFI::Platypus;
  
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->load_custom_type('::StringPointer' => 'string_pointer');
  
  $ffi->attach(string_pointer_argument => ['string_pointer'] => 'void');
@@ -57,7 +57,7 @@ use constant _incantation =>
   $^O eq 'MSWin32' && $Config::Config{archname} =~ /MSWin32-x64/
   ? 'Q'
   : 'L!';
-use constant _pointer_buffer => "P" . FFI::Platypus->new->sizeof('opaque');
+use constant _pointer_buffer => "P" . FFI::Platypus->new( api => 1, experimental => 1 )->sizeof('opaque');
 
 my @stack;
 


### PR DESCRIPTION
for:

 * #181 
 * Update all documentation to use `api => 1` (explicit) instead of `api => 0` (implicit). Remaining .pm files that need updating:
   * [x] FFI::Platypus::Type
   * [x] FFI::Platypus::Type needs to document the `object` type.
   * [x] FFI::Platypus::Record
 * Other nits:
   * [x] For records, return opaque, cast and free for APIs that expect you to clean up after them (#186)
   * [x] The FAQ for constants should be updated to mention enum types.
   * [x] The FAQ for constants should link to FFI::Platypus::Constant. This can wait until the interface is non-experimental.
