### PR TITLE
POD fix - String custom type example

### DIFF
--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -387,6 +387,7 @@ custom type:
      my($ptr) = @_;
      my $str = $ffi->cast( 'opaque' => 'string', $ptr ); # copies the string
      free_string($ptr);
+     $str;
    }
  });
  


### PR DESCRIPTION
Hi!  I think the native_to_perl example code here needs to return the newly-cast string