### PR TITLE
Type nits

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - pointer is no longer an alias for opaque with api => 1 (gh#189)
+  - Added several reserved words for the type parser when api => 1 (gh#189)
 
 0.97_03   2019-09-25 18:03:13 -0600
   - FFI::Platypus::Record has a record_layout_1 function which

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -382,7 +382,7 @@ sub lang
       $type_map{$_} = $_ for grep { $self->{tp}->have_type($_) }
         qw( void sint8 uint8 sint16 uint16 sint32 uint32 sint64 uint64 float double string opaque
             longdouble complex_float complex_double );
-      $type_map{pointer} = 'opaque';
+      $type_map{pointer} = 'opaque' if $self->{tp}->isa('FFI::Platypus::TypeParser::Version0');
       $self->{tp}->type_map(\%type_map);
     }
   }

--- a/lib/FFI/Platypus/TypeParser.pm
+++ b/lib/FFI/Platypus/TypeParser.pm
@@ -85,8 +85,6 @@ sub types
     $store{rev}->{$type_code} = $name;
   }
 
-  $store{$_}->{pointer} = $store{$_}->{opaque} for qw( basic ptr );
-
   sub global_types
   {
     \%store;

--- a/lib/FFI/Platypus/TypeParser/Version1.pm
+++ b/lib/FFI/Platypus/TypeParser/Version1.pm
@@ -45,9 +45,13 @@ The API C<0.02> type parser.
 our @CARP_NOT = qw( FFI::Platypus FFI::Platypus::TypeParser );
 
 my %reserved = map { $_ => 1 } qw(
+  string
+  object
+  class
   struct
   record
   string
+  array
   senum
   enum
 );


### PR DESCRIPTION
With the original type parser, `pointer` was allowed as an alias for `opaque`.  I decided almost immediately that was a mistake, but never removed it although it was probably safe to do so at the time.  Now it's too late to remove it from tp 0, but we CAN remove it from tp 1 since we are still experimental for `api => 1`.

Also add a few reserved words to type parser 1, that we might want to use later.