### PR TITLE
Fix bug in variadic function argument count

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Fix bug in variadic argument count (gh#210, gh#211)
 
 1.06      2019-12-14 07:49:54 -0700
   - Visual C++ Perl build probe for ssize_t (gh#208, gh#209)

--- a/inc/Alien/Base/Wrapper.pm
+++ b/inc/Alien/Base/Wrapper.pm
@@ -16,7 +16,7 @@ use Text::ParseWords qw( shellwords );
 # distributed with Alien-Build.
 
 # ABSTRACT: Compiler and linker wrapper for Alien
-our $VERSION = '1.93'; # VERSION
+our $VERSION = '1.94'; # VERSION
 
 
 my @cflags_I;
@@ -201,7 +201,7 @@ Alien::Base::Wrapper - Compiler and linker wrapper for Alien
 
 =head1 VERSION
 
-version 1.93
+version 1.94
 
 =head1 SYNOPSIS
 

--- a/inc/probe/variadic.c
+++ b/inc/probe/variadic.c
@@ -45,7 +45,7 @@ ffi_test()
   void *ptrvalues[8]  = { &values[0], &values[1], &values[2], &values[3], &values[4], &values[5], &values[6], &values[7] };
   int answer = -1;
 
-  if(ffi_prep_cif_var(&cif, FFI_DEFAULT_ABI, 1, 7, &ffi_type_sint32, args) == FFI_OK)
+  if(ffi_prep_cif_var(&cif, FFI_DEFAULT_ABI, 1, 8, &ffi_type_sint32, args) == FFI_OK)
   {
     ffi_call(&cif, (void*) return_arg, &answer, ptrvalues);
     if(answer != 40)

--- a/t/ffi/variadic.c
+++ b/t/ffi/variadic.c
@@ -2,8 +2,9 @@
 #ifdef FFI_PL_PROBE_VARIADIC
 #include <stdio.h>
 #include <stdarg.h>
+#include "libtest.h"
 
-int
+EXTERN int
 variadic_return_arg(int which, ...)
 {
   va_list args;

--- a/t/ffi/variadic.c
+++ b/t/ffi/variadic.c
@@ -7,18 +7,67 @@
 EXTERN int
 variadic_return_arg(int which, ...)
 {
-  va_list args;
-  va_start(args, which);
+  va_list ap;
   int i, val;
+
+  va_start(ap, which);
 
   for(i=0; i<which; i++)
   {
-    val = va_arg(args, int);
+    val = va_arg(ap, int);
   }
 
-  va_end(args);
+  va_end(ap);
 
   return val;
+}
+
+EXTERN const char *
+xprintf(const char *fmt, ...)
+{
+  va_list ap;
+  static char buffer[2046];
+  char *bp=buffer;
+
+  va_start(ap, fmt);
+
+  while(*fmt != '\0')
+  {
+    switch(*fmt)
+    {
+      case '%':
+        {
+          char buffer2[64];
+          const char *str=buffer2;
+          switch(*(++fmt))
+          {
+            case 'd':
+              sprintf(buffer2, "%d", va_arg(ap, int));
+              break;
+            case 's':
+              str = va_arg(ap, char *);
+              break;
+            default:
+              str = "[fmt error]";
+              break;
+          }
+          strcpy(bp, str);
+          bp += strlen(str);
+        }
+        break;
+
+      default:
+        *(bp++) = *fmt;
+        break;
+    }
+    fmt++;
+  }
+
+  va_end(ap);
+
+  *bp = '\0';
+
+  return buffer;
 }
 
 #endif

--- a/t/ffi_platypus_function.t
+++ b/t/ffi_platypus_function.t
@@ -173,6 +173,25 @@ subtest 'variadic' => sub {
 
   };
 
+  subtest 'examples' => sub {
+
+    is(
+      $ffi->function( xprintf => ['string'] => ['int'] => 'string' )->call("print integer %d\n", 42),
+      "print integer 42\n",
+    );
+
+    is(
+      $ffi->function( xprintf => ['string'] => ['string'] => 'string' )->call("print string %s\n", 'platypus'),
+      "print string platypus\n",
+    );
+
+    is(
+      $ffi->function( xprintf => ['string'] => ['int','string'] => 'string' )->call("print integer %d and string %s\n", 42, 'platypus'),
+      "print integer 42 and string platypus\n",
+    );
+
+  };
+
 };
 
 subtest 'void as arg should fail is arg count > 1' => sub {
@@ -194,4 +213,3 @@ subtest 'single void arg treated as no args' => sub {
 };
 
 done_testing;
-

--- a/t/ffi_platypus_function.t
+++ b/t/ffi_platypus_function.t
@@ -144,26 +144,32 @@ subtest 'variadic' => sub {
 
   subtest 'unattached' => sub {
 
-    is(
-      $ffi->function(variadic_return_arg => ['int'] => ['int','int','int','int','int','int','int'] => 'int')->call(4,10,20,30,40,50,60,70),
-      40,
-      'sans wrapper'
-    );
+    foreach my $i (1..7)
+    {
+      is(
+        $ffi->function(variadic_return_arg => ['int'] => ['int','int','int','int','int','int','int'] => 'int')->call($i,10,20,30,40,50,60,70),
+        $i*10,
+        'sans wrapper'
+      );
 
-    is(
-      $ffi->function(variadic_return_arg => ['int'] => ['int','int','int','int','int','int','int'] => 'int', $wrapper)->call(4,10,20,30,40,50,60,70),
-      80,
-      'with wrapper'
-    );
+      is(
+        $ffi->function(variadic_return_arg => ['int'] => ['int','int','int','int','int','int','int'] => 'int', $wrapper)->call($i,10,20,30,40,50,60,70),
+        $i*10*2,
+        'with wrapper'
+      );
+    }
   };
 
   subtest 'attached' => sub {
 
     $ffi->attach([variadic_return_arg => 'y1'] => ['int'] => ['int','int','int','int','int','int','int'] => 'int');
-    is(y1(4,10,20,30,40,50,60,70), 40, 'sans wrapper');
-
     $ffi->attach([variadic_return_arg => 'y2'] => ['int'] => ['int','int','int','int','int','int','int'] => 'int', $wrapper);
-    is(y2(4,10,20,30,40,50,60,70), 80, 'with wrapper');
+
+    foreach my $i (1..7)
+    {
+      is(y1($i,10,20,30,40,50,60,70), $i*10, 'sans wrapper');
+      is(y2($i,10,20,30,40,50,60,70), $i*10*2, 'with wrapper');
+    }
 
   };
 

--- a/xs/Function.xs
+++ b/xs/Function.xs
@@ -143,7 +143,7 @@ new(class, platypus, address, abi, var_fixed_args, return_type, ...)
         &self->ffi_cif,                           /* ffi_cif     | */
         ffi_abi,                                  /* ffi_abi     | */
         var_fixed_args,                           /* int         | fixed argument count */
-        items-6+extra_arguments-var_fixed_args,   /* int         | var argument count */
+        items-6+extra_arguments,                  /* int         | total argument count */
         ffi_return_type,                          /* ffi_type *  | return type */
         ffi_argument_types                        /* ffi_type ** | argument types */
       );


### PR DESCRIPTION
The argument name for `ffi_prep_cif_var` was named to something that sounded like it was just the variable arguments, but according to the documentation is actually a count of alllll of the arguments.  The tests that I wrote just happen to work with the wrong input (at least on x86).  This adjusts the tests to be more aggressive, including some tests that are similar to the examples that we site in the documentation (which I apparently never tested).  This should fix #210.