### PR TITLE
add FFI::Platypus:Buffer::grow(), which ensures an existing scalar has a given size

### DIFF
--- a/lib/FFI/Platypus.xs
+++ b/lib/FFI/Platypus.xs
@@ -96,3 +96,4 @@ INCLUDE: ../../xs/API.xs
 INCLUDE: ../../xs/ABI.xs
 INCLUDE: ../../xs/Record.xs
 INCLUDE: ../../xs/Closure.xs
+INCLUDE: ../../xs/Buffer.xs

--- a/lib/FFI/Platypus/Buffer.pm
+++ b/lib/FFI/Platypus/Buffer.pm
@@ -152,10 +152,6 @@ C<length($scalar) == 0>
 Any pointers obtained with C<scalar_to_pointer> or C<scalar_to_buffer>
 are no longer valid after growing the scalar.  By default,
 
-
-=cut
-
-
 =head1 SEE ALSO
 
 =over 4

--- a/lib/FFI/Platypus/Buffer.pm
+++ b/lib/FFI/Platypus/Buffer.pm
@@ -152,6 +152,8 @@ C<length($scalar) == 0>
 Any pointers obtained with C<scalar_to_pointer> or C<scalar_to_buffer>
 are no longer valid after growing the scalar.  By default,
 
+Not exported by default, but may be exported on request.
+
 =head2 set_used_length
 
  set_used_length $scalar, $length;
@@ -187,6 +189,7 @@ number actually written.
   # unpack the native doubles into a Perl array
   my @doubles = unpack( 'd*', $buffer );  # @doubles == $num_read
 
+Not exported by default, but may be exported on request.
 
 =head1 SEE ALSO
 

--- a/lib/FFI/Platypus/Buffer.pm
+++ b/lib/FFI/Platypus/Buffer.pm
@@ -2,10 +2,11 @@ package FFI::Platypus::Buffer;
 
 use strict;
 use warnings;
+use FFI::Platypus;
 use base qw( Exporter );
 
 our @EXPORT = qw( scalar_to_buffer buffer_to_scalar );
-our @EXPORT_OK = qw ( scalar_to_pointer );
+our @EXPORT_OK = qw ( scalar_to_pointer grow );
 
 # ABSTRACT: Convert scalars to C buffers
 # VERSION
@@ -126,6 +127,18 @@ sub buffer_to_scalar ($$)
 }
 
 1;
+
+=head2 grow
+
+ grow $scalar, $size;
+
+Ensure that the scalar is at least C<$size> bytes in length. Any
+pointers obtained with C<scalar_to_pointer> or C<scalar_to_buffer> are
+no longer valid after growing the scalar.
+
+
+=cut
+
 
 =head1 SEE ALSO
 

--- a/lib/FFI/Platypus/Buffer.pm
+++ b/lib/FFI/Platypus/Buffer.pm
@@ -131,10 +131,26 @@ sub buffer_to_scalar ($$)
 =head2 grow
 
  grow $scalar, $size;
+ grow $scalar, $size, $clear;
 
-Ensure that the scalar is at least C<$size> bytes in length. Any
-pointers obtained with C<scalar_to_pointer> or C<scalar_to_buffer> are
-no longer valid after growing the scalar.
+Ensure that the scalar can contain at least C<$size> bytes.  C<$clear>
+determines if the scalar is cleared before it is enlarged, which
+avoids copying the original contents to newly allocated storage.  If
+C<$clear> is not specified or is true, the scalar is cleared,
+otherwise it is not.  For example, after
+
+   $scalar = "my string";
+   grow $scalar, 100, 0;
+
+C<$scalar == "my string">, while after
+
+   $scalar = "my string";
+   grow $scalar, 100;
+
+C<length($scalar) == 0>
+
+Any pointers obtained with C<scalar_to_pointer> or C<scalar_to_buffer>
+are no longer valid after growing the scalar.  By default,
 
 
 =cut

--- a/lib/FFI/Platypus/Buffer.pm
+++ b/lib/FFI/Platypus/Buffer.pm
@@ -141,7 +141,7 @@ following are recognized:
 
 If true, C<$scalar> is cleared prior to being enlarged.  This
 avoids copying the existing contents to the reallocated memory
-if they are not needed.  It defaults to C<true>.
+if they are not needed.
 
   For example, after
 
@@ -155,6 +155,8 @@ C<$scalar == "my string">, while after
 
 C<length($scalar) == 0>
 
+It defaults to C<true>.
+
 =item set_length => I<boolean>
 
 If true, the length of the I<string> in the C<$scalar> is set to C<$size>.
@@ -162,16 +164,18 @@ If true, the length of the I<string> in the C<$scalar> is set to C<$size>.
 foreign function writes exactly C<$size> bytes to C<$scalar>, as it avoids
 a subsequent call to C<set_used_length>.  Contrast this
 
-  grow my $scalar, 100, { set_length => 1 };
+  grow my $scalar, 100;
   read_exactly_100_bytes_into_scalar( scalar_to_pointer($scalar) );
   @chars = unpack( 'c*', $scalar );
 
 with this:
 
-  grow my $scalar, 100;
+  grow my $scalar, 100, { set_length => 0 };
   read_exactly_100_bytes_into_scalar( scalar_to_pointer($scalar) );
   set_used_length( $scalar, 100 );
   @chars = unpack( 'c*', $scalar );
+
+It defaults to C<true>.
 
 =back
 

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -1,12 +1,14 @@
 use strict;
 use warnings;
 use utf8;
+use B;
+
 # see https://github.com/Perl5-FFI/FFI-Platypus/issues/85
 use if $^O ne 'MSWin32' || $] >= 5.018, 'open', ':std', ':encoding(utf8)';
 use Test::More;
 use Encode qw( decode );
 use FFI::Platypus::Buffer;
-use FFI::Platypus::Buffer qw( scalar_to_pointer );
+use FFI::Platypus::Buffer qw( scalar_to_pointer grow );
 
 subtest simple => sub {
   my $orig = 'me grimlock king';
@@ -26,6 +28,21 @@ subtest unicode => sub {
   ok $size, "size = $size";
   my $scalar = decode('UTF-8', buffer_to_scalar($ptr, $size));
   is $scalar, 'привет', "scalar = $scalar";
+};
+
+subtest grow => sub {
+  my $orig = 'me grimlock king';
+  my($ptr, $size) = scalar_to_buffer($orig);
+  my $sv = B::svref_2object( \$orig );
+  is $sv->CUR, $size, "consistent string lengths";
+
+  my $required = 100;
+  ok $sv->LEN < $required, "initial buffer size is smaler than required";
+
+  # in my tests, you never get exactly what you ask for
+  grow( $orig, $required );
+  ok $sv->LEN > $required, "buffer grew as expected";
+
 };
 
 done_testing;

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -45,7 +45,7 @@ subtest grow => sub {
     # in my tests, you never get exactly what you ask for
     grow( $str, $required );
     my $sv = B::svref_2object( \$str );
-    ok $sv->LEN => $required, "buffer grew as expected";
+    ok $sv->LEN >= $required, "buffer grew as expected";
     is $sv->CUR, 0,  "buffer contents cleared";
   };
 
@@ -55,7 +55,7 @@ subtest grow => sub {
     # in my tests, you never get exactly what you ask for
     grow( $str, $required, 0 );
     my $sv = B::svref_2object( \$str );
-    ok $sv->LEN => $required, "buffer grew as expected";
+    ok $sv->LEN >= $required, "buffer grew as expected";
     is $str, $orig,  "buffer contents remain";
   };
 

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -31,17 +31,33 @@ subtest unicode => sub {
 };
 
 subtest grow => sub {
-  my $orig = 'me grimlock king';
-  my($ptr, $size) = scalar_to_buffer($orig);
-  my $sv = B::svref_2object( \$orig );
-  is $sv->CUR, $size, "consistent string lengths";
+    my $orig = 'me grimlock king';
+    my($ptr, $size) = scalar_to_buffer($orig);
+    my $sv = B::svref_2object( \$orig );
+    is $sv->CUR, $size, "B::PV returns consistent string length";
 
-  my $required = 100;
-  ok $sv->LEN < $required, "initial buffer size is smaler than required";
+    my $required = 100;
+    ok $sv->LEN < $required, "initial buffer size is smaler than required";
 
-  # in my tests, you never get exactly what you ask for
-  grow( $orig, $required );
-  ok $sv->LEN > $required, "buffer grew as expected";
+  subtest clear => sub {
+    my $str = $orig;
+
+    # in my tests, you never get exactly what you ask for
+    grow( $str, $required );
+    my $sv = B::svref_2object( \$str );
+    ok $sv->LEN > $required, "buffer grew as expected";
+    is $sv->CUR, 0,  "buffer contents cleared";
+  };
+
+  subtest "don't clear" => sub {
+    my $str = $orig;
+
+    # in my tests, you never get exactly what you ask for
+    grow( $str, $required, 0 );
+    my $sv = B::svref_2object( \$str );
+    ok $sv->LEN > $required, "buffer grew as expected";
+    is $str, $orig,  "buffer contents remain";
+  };
 
 };
 

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -8,7 +8,7 @@ use if $^O ne 'MSWin32' || $] >= 5.018, 'open', ':std', ':encoding(utf8)';
 use Test::More;
 use Encode qw( decode );
 use FFI::Platypus::Buffer;
-use FFI::Platypus::Buffer qw( scalar_to_pointer grow );
+use FFI::Platypus::Buffer qw( scalar_to_pointer grow set_length );
 
 subtest simple => sub {
   my $orig = 'me grimlock king';
@@ -58,6 +58,32 @@ subtest grow => sub {
     ok $sv->LEN >= $required, "buffer grew as expected";
     is $str, $orig,  "buffer contents remain";
   };
+
+};
+
+subtest set_length => sub {
+    my $orig = 'me grimlock king';
+
+   subtest 'length < max' => sub {
+      my $str = $orig;
+      my $len = set_length( $str, 3 );
+      is( $len, 3, "requested length" );
+      is( $str, "me ", "requested string" );
+   };
+
+   subtest 'length == max' => sub {
+      my $str = $orig;
+      my $sv = B::svref_2object( \$str );
+      my $len = set_length( $str, $sv->LEN );
+      is( $len, $sv->LEN, "requested length" );
+   };
+
+   subtest 'length > max' => sub {
+      my $str = $orig;
+      my $sv = B::svref_2object( \$str );
+      my $len = set_length( $str, $sv->LEN + 10);
+      is( $len, $sv->LEN, "maxed out length" );
+   };
 
 };
 

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -44,14 +44,15 @@ subtest grow => sub {
     grow( $str, $required );
     my $sv = B::svref_2object( \$str );
     ok $sv->LEN >= $required, "buffer grew as expected";
-    is $sv->CUR, 0,  "buffer contents cleared";
+    isnt substr( $str, 0, length($orig) ), $orig, "original contents cleared";
+    is $sv->CUR, $required,  "string length == requested buffer length";
   };
 
   subtest clear => sub {
 
     subtest 'on' => sub {
       my $str = $orig;
-      grow( $str, $required, { clear => 1 }  );
+      grow( $str, $required, { clear => 1, set_length => 0 }  );
       my $sv = B::svref_2object( \$str );
       ok $sv->LEN >= $required, "buffer grew as expected";
       is $sv->CUR, 0,  "buffer contents cleared";
@@ -59,7 +60,7 @@ subtest grow => sub {
 
     subtest 'off' => sub {
       my $str = $orig;
-      grow( $str, $required, { clear => 0 }  );
+      grow( $str, $required, { clear => 0, set_length => 0 }  );
       my $sv = B::svref_2object( \$str );
       ok $sv->LEN >= $required, "buffer grew as expected";
       is $str, $orig,  "buffer contents not cleared";

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -64,9 +64,20 @@ subtest grow => sub {
     eval { grow( $ref, 0 ); };
     my $err = $@;
     like ( $err, qr/argument error/, "croaked" );
-  }
+  };
 
+  subtest '$str = undef' => sub {
+    my $str;
+    grow( $str, $required, 0 );
+    my $sv = B::svref_2object( \$str );
+    ok $sv->LEN >= $required, "buffer grew as expected";
+  };
 
+  subtest 'undef' => sub {
+    eval { grow( undef, $required, 0 ) };
+    my $err = $@;
+    like ( $err, qr/read-only/, "croaked" );
+  };
 };
 
 subtest set_used_length => sub {
@@ -98,7 +109,21 @@ subtest set_used_length => sub {
     eval { set_used_length( $ref, 0 ); };
     my $err = $@;
     like ( $err, qr/argument error/, "croaked" );
-  }
+  };
+
+  subtest '$str = undef' => sub {
+    my $str;
+    my $len = set_used_length( $str, 100);
+    my $sv = B::svref_2object( \$str );
+    is ( $len, 0, "no added length" );
+    is( $len, $sv->LEN, "maxed out length" );
+  };
+
+  subtest 'undef' => sub {
+    eval { set_used_length( undef, 0 ) };
+    my $err = $@;
+    like ( $err, qr/read-only/, "croaked" );
+  };
 };
 
 done_testing;

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -45,7 +45,7 @@ subtest grow => sub {
     # in my tests, you never get exactly what you ask for
     grow( $str, $required );
     my $sv = B::svref_2object( \$str );
-    ok $sv->LEN > $required, "buffer grew as expected";
+    ok $sv->LEN => $required, "buffer grew as expected";
     is $sv->CUR, 0,  "buffer contents cleared";
   };
 
@@ -55,7 +55,7 @@ subtest grow => sub {
     # in my tests, you never get exactly what you ask for
     grow( $str, $required, 0 );
     my $sv = B::svref_2object( \$str );
-    ok $sv->LEN > $required, "buffer grew as expected";
+    ok $sv->LEN => $required, "buffer grew as expected";
     is $str, $orig,  "buffer contents remain";
   };
 

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -59,6 +59,14 @@ subtest grow => sub {
     is $str, $orig,  "buffer contents remain";
   };
 
+  subtest "fail on reference" => sub {
+    my $ref = \$orig;
+    eval { grow( $ref, 0 ); };
+    my $err = $@;
+    like ( $err, qr/argument error/, "croaked" );
+  }
+
+
 };
 
 subtest set_used_length => sub {
@@ -85,6 +93,12 @@ subtest set_used_length => sub {
       is( $len, $sv->LEN, "maxed out length" );
    };
 
+  subtest "fail on reference" => sub {
+    my $ref = \$orig;
+    eval { set_used_length( $ref, 0 ); };
+    my $err = $@;
+    like ( $err, qr/argument error/, "croaked" );
+  }
 };
 
 done_testing;

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -8,7 +8,7 @@ use if $^O ne 'MSWin32' || $] >= 5.018, 'open', ':std', ':encoding(utf8)';
 use Test::More;
 use Encode qw( decode );
 use FFI::Platypus::Buffer;
-use FFI::Platypus::Buffer qw( scalar_to_pointer grow set_length );
+use FFI::Platypus::Buffer qw( scalar_to_pointer grow set_used_length );
 
 subtest simple => sub {
   my $orig = 'me grimlock king';
@@ -61,12 +61,12 @@ subtest grow => sub {
 
 };
 
-subtest set_length => sub {
+subtest set_used_length => sub {
     my $orig = 'me grimlock king';
 
    subtest 'length < max' => sub {
       my $str = $orig;
-      my $len = set_length( $str, 3 );
+      my $len = set_used_length( $str, 3 );
       is( $len, 3, "requested length" );
       is( $str, "me ", "requested string" );
    };
@@ -74,14 +74,14 @@ subtest set_length => sub {
    subtest 'length == max' => sub {
       my $str = $orig;
       my $sv = B::svref_2object( \$str );
-      my $len = set_length( $str, $sv->LEN );
+      my $len = set_used_length( $str, $sv->LEN );
       is( $len, $sv->LEN, "requested length" );
    };
 
    subtest 'length > max' => sub {
       my $str = $orig;
       my $sv = B::svref_2object( \$str );
-      my $len = set_length( $str, $sv->LEN + 10);
+      my $len = set_used_length( $str, $sv->LEN + 10);
       is( $len, $sv->LEN, "maxed out length" );
    };
 

--- a/t/ffi_platypus_buffer.t
+++ b/t/ffi_platypus_buffer.t
@@ -111,6 +111,10 @@ subtest set_used_length => sub {
     like ( $err, qr/argument error/, "croaked" );
   };
 
+TODO : {
+
+  local $TODO = "is set_used_length undef behavior correct?";
+
   subtest '$str = undef' => sub {
     my $str;
     my $len = set_used_length( $str, 100);
@@ -118,6 +122,8 @@ subtest set_used_length => sub {
     is ( $len, 0, "no added length" );
     is( $len, $sv->LEN, "maxed out length" );
   };
+
+}
 
   subtest 'undef' => sub {
     eval { set_used_length( undef, 0 ) };

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -16,7 +16,11 @@ grow (sv, size)
     if (!SvPOK (sv))
         sv_setpvn (sv, "", 0);
     /* don't need the contents; avoid copying into the new memory */
+#if PERL_API_VERSION >= 26
     SvPVCLEAR(sv);
+#else
+    sv_setpvn (sv, "", 0);
+#endif
     SvGROW (sv, size);
     EXTEND (SP, 1);
     mPUSHi (SvLEN (sv));

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -14,7 +14,7 @@ grow (sv, size, ... )
         clear = SvIV(ST(2));
 
     if (SvROK (sv))
-        sv = SvRV (sv);
+        croak("argument error: buffer must be a scalar");
     if (!SvPOK (sv))
         sv_setpvn (sv, "", 0);
     /* don't need the contents; avoid copying into the new memory */
@@ -42,7 +42,7 @@ set_used_length( sv, size )
     STRLEN len;
   CODE:
     if (SvROK (sv))
-        sv = SvRV (sv);
+        croak("argument error: buffer must be a scalar");
     if (!SvPOK (sv))
         sv_setpvn (sv, "", 0);
 

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -1,6 +1,5 @@
 MODULE = FFI::Platypus PACKAGE = FFI::Platypus::Buffer
 
-# Stolen from Data::Peek::DGrow
 void
 grow (sv, size, ... )
     SV     *sv
@@ -29,7 +28,6 @@ grow (sv, size, ... )
     SvGROW (sv, size);
     EXTEND (SP, 1);
     mPUSHi (SvLEN (sv));
-    /* XS DGrow */
 
 
 STRLEN

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -1,0 +1,23 @@
+MODULE = FFI::Platypus PACKAGE = FFI::Platypus::Buffer
+
+# Stolen from Data::Peek::DGrow
+
+
+
+void
+grow (sv, size)
+    SV     *sv
+    IV      size
+ 
+  PROTOTYPE: $$
+  PPCODE:
+    if (SvROK (sv))
+        sv = SvRV (sv);
+    if (!SvPOK (sv))
+        sv_setpvn (sv, "", 0);
+    /* don't need the contents; avoid copying into the new memory */
+    SvPVCLEAR(sv);
+    SvGROW (sv, size);
+    EXTEND (SP, 1);
+    mPUSHi (SvLEN (sv));
+    /* XS DGrow */

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -4,7 +4,7 @@ MODULE = FFI::Platypus PACKAGE = FFI::Platypus::Buffer
 void
 grow (sv, size, ... )
     SV     *sv
-    IV      size
+    STRLEN      size
  
   PROTOTYPE: $$;$
   PREINIT:
@@ -35,7 +35,7 @@ grow (sv, size, ... )
 STRLEN
 set_used_length( sv, size )
     SV     *sv
-    IV      size
+    STRLEN      size
 
   PROTOTYPE: $$
   PREINIT:

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -8,7 +8,7 @@ grow (sv, size, ... )
   PROTOTYPE: $$;$
   PREINIT:
     int clear = 1;
-    int set_length = 0;
+    int set_length = 1;
 
   PPCODE:
     if (SvROK (sv))

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -14,16 +14,16 @@ grow (sv, size, ... )
 
     if (SvROK (sv))
         croak("argument error: buffer must be a scalar");
-    if (!SvPOK (sv))
-        sv_setpvn (sv, "", 0);
-    /* don't need the contents; avoid copying into the new memory */
-
-    if (clear)
-#if PERL_API_VERSION >= 26
-      SvPVCLEAR(sv);
+        
+    /* if not a string turn it into an empty one, or if clearing is
+       requested, reset string length */
+    if (!SvPOK (sv) || clear ) {
+#     if PERL_API_VERSION >= 26
+        SvPVCLEAR(sv);
 #else
-      sv_setpvn (sv, "", 0);
+        sv_setpvn (sv, "", 0);
 #endif
+    }
 
     SvGROW (sv, size);
     EXTEND (SP, 1);
@@ -41,6 +41,8 @@ set_used_length( sv, size )
   CODE:
     if (SvROK (sv))
         croak("argument error: buffer must be a scalar");
+
+    /* add some stringiness if necessary; svCUR_set only works on PV's */
     if (!SvPOK (sv))
         sv_setpvn (sv, "", 0);
 

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -10,7 +10,7 @@ grow (sv, size, ... )
     int clear = 1;  
   PPCODE:
     if ( items > 2 )
-        clear = SvIV(ST(2));
+        clear = SvTRUE(ST(2));
 
     if (SvROK (sv))
         croak("argument error: buffer must be a scalar");

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -18,7 +18,7 @@ grow (sv, size, ... )
     /* if not a string turn it into an empty one, or if clearing is
        requested, reset string length */
     if (!SvPOK (sv) || clear ) {
-#     if PERL_API_VERSION >= 26
+#if PERL_API_VERSION >= 26
         SvPVCLEAR(sv);
 #else
         sv_setpvn (sv, "", 0);

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -5,22 +5,30 @@ MODULE = FFI::Platypus PACKAGE = FFI::Platypus::Buffer
 
 
 void
-grow (sv, size)
+grow (sv, size, ... )
     SV     *sv
     IV      size
  
-  PROTOTYPE: $$
+  PROTOTYPE: $$;$
+  PREINIT:
+    int clear = 1;  
   PPCODE:
+    if ( items > 2 )
+        clear = SvIV(ST(2));
+
     if (SvROK (sv))
         sv = SvRV (sv);
     if (!SvPOK (sv))
         sv_setpvn (sv, "", 0);
     /* don't need the contents; avoid copying into the new memory */
+
+    if (clear)
 #if PERL_API_VERSION >= 26
-    SvPVCLEAR(sv);
+      SvPVCLEAR(sv);
 #else
-    sv_setpvn (sv, "", 0);
+      sv_setpvn (sv, "", 0);
 #endif
+
     SvGROW (sv, size);
     EXTEND (SP, 1);
     mPUSHi (SvLEN (sv));

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -1,9 +1,6 @@
 MODULE = FFI::Platypus PACKAGE = FFI::Platypus::Buffer
 
 # Stolen from Data::Peek::DGrow
-
-
-
 void
 grow (sv, size, ... )
     SV     *sv
@@ -33,3 +30,24 @@ grow (sv, size, ... )
     EXTEND (SP, 1);
     mPUSHi (SvLEN (sv));
     /* XS DGrow */
+
+
+STRLEN
+set_used_length( sv, size )
+    SV     *sv
+    IV      size
+
+  PROTOTYPE: $$
+  PREINIT:
+    STRLEN len;
+  CODE:
+    if (SvROK (sv))
+        sv = SvRV (sv);
+    if (!SvPOK (sv))
+        sv_setpvn (sv, "", 0);
+
+    len = SvLEN( sv );
+    RETVAL = size > len ? len : size;
+    SvCUR_set( sv, RETVAL );
+  OUTPUT:
+    RETVAL

--- a/xs/Buffer.xs
+++ b/xs/Buffer.xs
@@ -13,8 +13,8 @@ grow (sv, size, ... )
         clear = SvTRUE(ST(2));
 
     if (SvROK (sv))
-        croak("argument error: buffer must be a scalar");
-        
+        croak("buffer argument must be a scalar");
+
     /* if not a string turn it into an empty one, or if clearing is
        requested, reset string length */
     if (!SvPOK (sv) || clear ) {
@@ -40,7 +40,7 @@ set_used_length( sv, size )
     STRLEN len;
   CODE:
     if (SvROK (sv))
-        croak("argument error: buffer must be a scalar");
+        croak("buffer argument must be a scalar");
 
     /* add some stringiness if necessary; svCUR_set only works on PV's */
     if (!SvPOK (sv))


### PR DESCRIPTION
This provides a thin wrapper around Perl's SvGROW(), allowing one to efficiently enlarge a buffer.  Code is mostly stolen from Data::Peek.