### PR TITLE
run -debug32 in ci too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
     - env: CIP_TAG=5.30-buster-arm64v8
       arch: arm64
     - env: CIP_TAG=5.30-debug
+    - env: CIP_TAG=5.30-debug32
     - env: CIP_TAG=5.30-buster32
     - env: CIP_TAG=5.30 CIP_ENV=FFI_PLATYPUS_MEMORY_STRDUP_IMPL=ffi
     - env: CIP_TAG=5.30-threads

--- a/include/ffi_platypus_call.h
+++ b/include/ffi_platypus_call.h
@@ -482,7 +482,15 @@
                       break;
 #ifdef FFI_PL_PROBE_LONGDOUBLE
                     case FFI_PL_TYPE_LONG_DOUBLE | FFI_PL_SHAPE_ARRAY:
-                      Newx(ptr, count, long double);
+                      /* gh#236: lets hope the compiler is smart enough to opitmize this */
+                      if(sizeof(long double) >= 16)
+                      {
+                        Newx(ptr, count, long double);
+                      }
+                      else
+                      {
+                        Newx(ptr, count*16, char);
+                      }
                       for(n=0; n<count; n++)
                       {
                         SV *sv = *av_fetch(av, n, 1);

--- a/maint/cip-before-install
+++ b/maint/cip-before-install
@@ -11,3 +11,7 @@ cip exec cpanm -n Math::LongDouble
 if [ "$CIP_TAG" == "5.30-debug" ]; then
   cip exec cpanm -n Test::LeakTrace
 fi
+
+if [ "$CIP_TAG" == "5.30-debug32" ]; then
+  cip exec cpanm -n Test::LeakTrace
+fi


### PR DESCRIPTION
There is a memory error in i386 that didn't present for some reason in x86_64

```
    # ==2471== Memcheck, a memory error detector
    # ==2471== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
    # ==2471== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
    # ==2471== Command: /opt/perl/5.30.2/bin/perl -Mblib corpus/memory/return_array.pl
    # ==2471== Parent PID: 2462
    # ==2471== 
    # ==2471== Invalid read of size 4
    # ==2471==    at 0x4839861: memcpy (vg_replace_strmem.c:1035)
    # ==2471==    by 0x540FD37: ffi_call_i386 (in /work/FFI-Platypus-1.17_01/blib/arch/auto/FFI/Platypus/Platypus.so)
    # ==2471==    by 0x540F102: ffi_call_int (in /work/FFI-Platypus-1.17_01/blib/arch/auto/FFI/Platypus/Platypus.so)
    # ==2471==    by 0x53DF616: XS_FFI__Platypus__Function__Function_call (ffi_platypus_call.h:661)
    # ==2471==    by 0x2DB565: Perl_pp_entersub (pp_hot.c:5237)
    # ==2471==    by 0x649ACE3: leaktrace_runops (LeakTrace.xs:184)
    # ==2471==    by 0x1772E4: S_run_body (perl.c:2711)
    # ==2471==    by 0x17681B: perl_run (perl.c:2639)
    # ==2471==    by 0x1321D5: main (perlmain.c:127)
    # ==2471==  Address 0x658dd08 is 0 bytes after a block of size 24 alloc'd
    # ==2471==    at 0x483463B: malloc (vg_replace_malloc.c:299)
    # ==2471==    by 0x27ADE2: Perl_safesysmalloc (util.c:155)
    # ==2471==    by 0x53DDF8C: XS_FFI__Platypus__Function__Function_call (ffi_platypus_call.h:483)
    # ==2471==    by 0x2DB565: Perl_pp_entersub (pp_hot.c:5237)
    # ==2471==    by 0x649ACE3: leaktrace_runops (LeakTrace.xs:184)
    # ==2471==    by 0x1772E4: S_run_body (perl.c:2711)
    # ==2471==    by 0x17681B: perl_run (perl.c:2639)
    # ==2471==    by 0x1321D5: main (perlmain.c:127)
    # ==2471== 
    # ==2471== Invalid read of size 4
    # ==2471==    at 0x4839867: memcpy (vg_replace_strmem.c:1035)
    # ==2471==    by 0x540FD37: ffi_call_i386 (in /work/FFI-Platypus-1.17_01/blib/arch/auto/FFI/Platypus/Platypus.so)
    # ==2471==    by 0x540F102: ffi_call_int (in /work/FFI-Platypus-1.17_01/blib/arch/auto/FFI/Platypus/Platypus.so)
    # ==2471==    by 0x53DF616: XS_FFI__Platypus__Function__Function_call (ffi_platypus_call.h:661)
    # ==2471==    by 0x2DB565: Perl_pp_entersub (pp_hot.c:5237)
    # ==2471==    by 0x649ACE3: leaktrace_runops (LeakTrace.xs:184)
    # ==2471==    by 0x1772E4: S_run_body (perl.c:2711)
    # ==2471==    by 0x17681B: perl_run (perl.c:2639)
    # ==2471==    by 0x1321D5: main (perlmain.c:127)
    # ==2471==  Address 0x658dd0c is 4 bytes after a block of size 24 alloc'd
    # ==2471==    at 0x483463B: malloc (vg_replace_malloc.c:299)
    # ==2471==    by 0x27ADE2: Perl_safesysmalloc (util.c:155)
    # ==2471==    by 0x53DDF8C: XS_FFI__Platypus__Function__Function_call (ffi_platypus_call.h:483)
    # ==2471==    by 0x2DB565: Perl_pp_entersub (pp_hot.c:5237)
    # ==2471==    by 0x649ACE3: leaktrace_runops (LeakTrace.xs:184)
    # ==2471==    by 0x1772E4: S_run_body (perl.c:2711)
    # ==2471==    by 0x17681B: perl_run (perl.c:2639)
    # ==2471==    by 0x1321D5: main (perlmain.c:127)
    # ==2471== 
    # ==2471== 
    # ==2471== HEAP SUMMARY:
    # ==2471==     in use at exit: 8,371 bytes in 68 blocks
    # ==2471==   total heap usage: 218,694 allocs, 218,626 frees, 20,201,743 bytes allocated
    # ==2471== 
    # ==2471== LEAK SUMMARY:
    # ==2471==    definitely lost: 0 bytes in 0 blocks
    # ==2471==    indirectly lost: 0 bytes in 0 blocks
    # ==2471==      possibly lost: 0 bytes in 0 blocks
    # ==2471==    still reachable: 8,243 bytes in 36 blocks
    # ==2471==         suppressed: 128 bytes in 32 blocks
    # ==2471== Reachable blocks (those to which a pointer was found) are not shown.
    # ==2471== To see them, rerun with: --leak-check=full --show-leak-kinds=all
    # ==2471== 
    # ==2471== For counts of detected and suppressed errors, rerun with: -v
    # ==2471== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 2 from 2)
    # Looks like you failed 1 test of 1.
```